### PR TITLE
Fix spelling error in var doc string

### DIFF
--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -316,10 +316,10 @@ Compute the sample variance of collection `itr`.
 The algorithm returns an estimator of the generative distribution's variance
 under the assumption that each entry of `itr` is an IID drawn from that generative
 distribution. For arrays, this computation is equivalent to calculating
-`sum((itr .- mean(itr)).^2) / (length(itr) - 1)).
+`sum((itr .- mean(itr)).^2) / (length(itr) - 1))`.
 If `corrected` is `true`, then the sum is scaled with `n-1`,
 whereas the sum is scaled with `n` if `corrected` is
-`false` with `n` the number of elements in `itr`.
+`false`. `n` is the number of elements in `itr`.
 
 A pre-computed `mean` may be provided.
 

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -319,7 +319,7 @@ distribution. For arrays, this computation is equivalent to calculating
 `sum((itr .- mean(itr)).^2) / (length(itr) - 1))`.
 If `corrected` is `true`, then the sum is scaled with `n-1`,
 whereas the sum is scaled with `n` if `corrected` is
-`false`. `n` is the number of elements in `itr`.
+`false` where `n` is the number of elements in `itr`.
 
 A pre-computed `mean` may be provided.
 


### PR DESCRIPTION
Just a small fix, a ` was missing. 