### PR TITLE
added quantile estimator with parameters alpha and beta

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,24 @@
+Statistics.jl is licensed under the MIT License:
+
+> Copyright (c) 2012-2016: Jeff Bezanson, Stefan Karpinski, Viral B. Shah,
+> Dahua Lin, Simon Byrne, Andreas Noack, Douglas Bates, John Myles White,
+> Simon Kornblith, and other contributors.
+
+> Permission is hereby granted, free of charge, to any person obtaining
+> a copy of this software and associated documentation files (the
+> "Software"), to deal in the Software without restriction, including
+> without limitation the rights to use, copy, modify, merge, publish,
+> distribute, sublicense, and/or sell copies of the Software, and to
+> permit persons to whom the Software is furnished to do so, subject to
+> the following conditions:
+>
+> The above copyright notice and this permission notice shall be
+> included in all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+> EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+> MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+> NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+> LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+> OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+> WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -936,24 +936,14 @@ end
     require_one_based_indexing(v)
 
     n = length(v)
+    m = α + p * (one(α) - α - β)
+    aleph = (n*p + m)
+    j = clamp(trunc(Int, aleph), 1, n-1)
+    γ = clamp(aleph - j, 0, 1)
 
-    if α==1 && β==1 # kept the specific implementation to avoid changing results on the level of machine precision
-        f0 = (n - 1)*p # 0-based interpolated index
-        t0 = trunc(f0)
-        γ  = f0 - t0
-        j  = trunc(Int,t0) + 1
+    a = v[j]
+    b = v[j + 1]
 
-        a = v[j]
-        b = v[j + (γ > 0)]
-    else # generic implementation
-        m = α + p * (one(α) - α - β)
-        aleph = (n*p + m)
-        j = clamp(trunc(Int, aleph), 1, n-1)
-        γ = clamp(aleph - j, 0, 1)
-
-        a = v[j]
-        b = v[j + 1]
-    end
     if isfinite(a) && isfinite(b)
         return a + γ*(b-a)
     else
@@ -1006,7 +996,7 @@ julia> quantile(0:20, [0.1, 0.5, 0.9])
   2.0
  10.0
  18.0
- 
+
 julia> quantile(skipmissing([1, 10, missing]), 0.5)
 5.5
 ```

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -974,9 +974,9 @@ where ``x[j]`` is the j-th order statistic, and `γ` is a function of
 `j = floor(n*p + m)`, `m = alpha + p*(1 - alpha - beta)` and
 `g = n*p + m - j`.
 
-As default (alpha=1, beta=alpha), quantiles are computed via linear interpolation between the points
+By default (`alpha = beta = 1`), quantiles are computed via linear interpolation between the points
 `((k-1)/(n-1), v[k])`, for `k = 1:n` where `n = length(itr)`. This corresponds to Definition 7
- of Hyndman and Fan (1996), and is the same as the R and NumPy default.
+of Hyndman and Fan (1996), and is the same as the R and NumPy default.
 
 The keyword arguments `alpha` and `beta` correspond to the same parameters in Hyndman and Fan,
 setting them to different values allows to calculate quantiles with any of the methods 4-9
@@ -990,6 +990,8 @@ defined in this paper:
 
 !!! note
     An `ArgumentError` is thrown if `v` contains `NaN` or [`missing`](@ref) values.
+    Use the [`skipmissing`](@ref) function to omit `missing` entries and compute the
+    quantiles of non-missing values.
 
 # References
 - Hyndman, R.J and Fan, Y. (1996) "Sample Quantiles in Statistical Packages",

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -842,7 +842,7 @@ defined in this paper:
 - Def. 4: `α=0`, `β=1`
 Def. 5: α=0.5, β=0.5
 Def. 6: α=0, β=0 (Excel PERCENTILE.EXC, Python exclusive-method)
-Def. 7: α=1, β=1 (Julia default, Excel PERCENTILE.INC, Python inclusive-method)
+Def. 7: α=1, β=1 (Julia, R and NumPy default, Excel `PERCENTILE` and `PERCENTILE.INC`, Python `'inclusive'`)
 Def. 8: α=1//3, β=1//3
 Def. 9: α=3//8, β=3//8
 

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -849,7 +849,7 @@ By default (`alpha = beta = 1`), quantiles are computed via linear interpolation
 `((k-1)/(n-1), v[k])`, for `k = 1:n` where `n = length(v)`. This corresponds to Definition 7
 of Hyndman and Fan (1996), and is the same as the R and NumPy default.
 
-The keyword parameters alpha and beta correspond to the same parameters in Hyndman and Fan,
+The keyword arguments `alpha` and `beta` correspond to the same parameters in Hyndman and Fan,
 setting them to different values allows to calculate quantiles with any of the methods 4-9
 defined in this paper:
 - Def. 4: `alpha=0`, `beta=1`

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -981,7 +981,7 @@ As default (alpha=1, beta=alpha), quantiles are computed via linear interpolatio
 `((k-1)/(n-1), v[k])`, for `k = 1:n` where `n = length(itr)`. This corresponds to Definition 7
  of Hyndman and Fan (1996), and is the same as the R and NumPy default.
 
-The keyword parameters alpha and beta correspond to the same parameters in Hyndman and Fan,
+The keyword arguments `alpha` and `beta` correspond to the same parameters in Hyndman and Fan,
 setting them to different values allows to calculate quantiles with any of the methods 4-9
 defined in this paper:
 - Def. 4: `alpha=0`, `beta=1`

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -847,7 +847,7 @@ where ``x[j]`` is the j-th order statistic, and `γ` is a function of
 
 By default (`alpha = beta = 1`), quantiles are computed via linear interpolation between the points
 `((k-1)/(n-1), v[k])`, for `k = 1:n` where `n = length(v)`. This corresponds to Definition 7
- of Hyndman and Fan (1996), and is the same as the R and NumPy default.
+of Hyndman and Fan (1996), and is the same as the R and NumPy default.
 
 The keyword parameters alpha and beta correspond to the same parameters in Hyndman and Fan,
 setting them to different values allows to calculate quantiles with any of the methods 4-9

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -852,7 +852,7 @@ Def. 9: α=3//8, β=3//8
 * Hyndman, R.J and Fan, Y. (1996) "Sample Quantiles in Statistical Packages",
   *The American Statistician*, Vol. 50, No. 4, pp. 361-365
 
-* https://en.m.wikipedia.org/wiki/Quantile
+* [Quantile on Wikipedia](https://en.m.wikipedia.org/wiki/Quantile) details the different quantile definitions
 
 
 # Examples

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -836,7 +836,7 @@ _median(v::AbstractArray{T}, ::Colon) where {T} = median!(copyto!(Array{T,1}(und
 # for now, use the R/S definition of quantile; may want variants later
 # see ?quantile in R -- this is type 7
 """
-    quantile!([q::AbstractArray, ] v::AbstractVector, p; sorted=false, alpha::Real=1, beta::Real=alpha)
+    quantile!([q::AbstractArray, ] v::AbstractVector, p; sorted=false, alpha::Real=1., beta::Real=alpha)
 
 Compute the quantile(s) of a vector `v` at a specified probability or vector or tuple of
 probabilities `p` on the interval [0,1]. If `p` is a vector, an optional
@@ -900,7 +900,7 @@ julia> y
 ```
 """
 function quantile!(q::AbstractArray, v::AbstractVector, p::AbstractArray;
-                   sorted::Bool=false, alpha::Real=1, beta::Real=alpha)
+                   sorted::Bool=false, alpha::Real=1., beta::Real=alpha)
     require_one_based_indexing(q, v, p)
     if size(p) != size(q)
         throw(DimensionMismatch("size of p, $(size(p)), must equal size of q, $(size(q))"))
@@ -917,7 +917,7 @@ function quantile!(q::AbstractArray, v::AbstractVector, p::AbstractArray;
 end
 
 function quantile!(v::AbstractVector, p::Union{AbstractArray, Tuple{Vararg{Real}}};
-                   sorted::Bool=false, alpha::Real=1, beta::Real=alpha)
+                   sorted::Bool=false, alpha::Real=1., beta::Real=alpha)
     if !isempty(p)
         minp, maxp = extrema(p)
         _quantilesort!(v, sorted, minp, maxp)
@@ -925,7 +925,7 @@ function quantile!(v::AbstractVector, p::Union{AbstractArray, Tuple{Vararg{Real}
     return map(x->_quantile(v, x, alpha=alpha, beta=beta), p)
 end
 
-quantile!(v::AbstractVector, p::Real; sorted::Bool=false, alpha::Real=1, beta::Real=alpha) =
+quantile!(v::AbstractVector, p::Real; sorted::Bool=false, alpha::Real=1., beta::Real=alpha) =
     _quantile(_quantilesort!(v, sorted, p, p), p, alpha=alpha, beta=beta)
 
 # Function to perform partial sort of v for quantiles in given range
@@ -949,7 +949,7 @@ function _quantilesort!(v::AbstractArray, sorted::Bool, minp::Real, maxp::Real)
 end
 
 # Core quantile lookup function: assumes `v` sorted
-@inline function _quantile(v::AbstractVector, p::Real; alpha::Real=1, beta::Real=alpha)
+@inline function _quantile(v::AbstractVector, p::Real; alpha::Real=1., beta::Real=alpha)
     0 <= p <= 1 || throw(ArgumentError("input probability out of [0,1] range"))
     0 <= alpha <= 1 || throw(ArgumentError("alpha parameter out of [0,1] range"))
     0 <= beta <= 1 || throw(ArgumentError("beta parameter out of [0,1] range"))
@@ -972,7 +972,7 @@ end
 end
 
 """
-    quantile(itr, p; sorted=false, alpha::Real=1, beta::Real=alpha)
+    quantile(itr, p; sorted=false, alpha::Real=1., beta::Real=alpha)
 
 Compute the quantile(s) of a collection `itr` at a specified probability or vector or tuple of
 probabilities `p` on the interval [0,1]. The keyword argument `sorted` indicates whether
@@ -1023,9 +1023,9 @@ julia> quantile(skipmissing([1, 10, missing]), 0.5)
 5.5
 ```
 """
-quantile(itr, p; sorted::Bool=false, alpha::Real=1, beta::Real=alpha) = quantile!(collect(itr), p, sorted=sorted, alpha=alpha, beta=beta)
+quantile(itr, p; sorted::Bool=false, alpha::Real=1., beta::Real=alpha) = quantile!(collect(itr), p, sorted=sorted, alpha=alpha, beta=beta)
 
-quantile(v::AbstractVector, p; sorted::Bool=false, alpha::Real=1, beta::Real=alpha) =
+quantile(v::AbstractVector, p; sorted::Bool=false, alpha::Real=1., beta::Real=alpha) =
     quantile!(sorted ? v : Base.copymutable(v), p; sorted=sorted, alpha=alpha, beta=beta)
 
 

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -834,7 +834,7 @@ _median(v::AbstractArray, dims) = mapslices(median!, v, dims = dims)
 _median(v::AbstractArray{T}, ::Colon) where {T} = median!(copyto!(Array{T,1}(undef, length(v)), v))
 
 """
-    quantile!([q::AbstractArray, ] v::AbstractVector, p; sorted=false, alpha::Real=1., beta::Real=alpha)
+    quantile!([q::AbstractArray, ] v::AbstractVector, p; sorted=false, alpha::Real=1.0, beta::Real=alpha)
 
 Compute the quantile(s) of a collection `itr` at a specified probability or vector or tuple of
 probabilities `p` on the interval [0,1]. The keyword argument `sorted` indicates whether

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -818,7 +818,7 @@ _median(v::AbstractArray{T}, ::Colon) where {T} = median!(copyto!(Array{T,1}(und
 # for now, use the R/S definition of quantile; may want variants later
 # see ?quantile in R -- this is type 7
 """
-    quantile!([q::AbstractArray, ] v::AbstractVector, p; sorted=false, α=1, β=α)
+    quantile!([q::AbstractArray, ] v::AbstractVector, p; sorted=false, α::Real=1, β::Real=α)
 
 Compute the quantile(s) of a vector `v` at a specified probability or vector or tuple of
 probabilities `p` on the interval [0,1]. If `p` is a vector, an optional
@@ -840,11 +840,11 @@ setting them to different values allows to calculate quantiles with any of the m
 defined in this paper:
 
 - Def. 4: `α=0`, `β=1`
-Def. 5: α=0.5, β=0.5
+- Def. 5: `α=0.5`, `β=0.5`
 - Def. 6: `α=0`, `β=0` (Excel `PERCENTILE.EXC`, Python default, Stata `altdef`)
-Def. 7: α=1, β=1 (Julia, R and NumPy default, Excel `PERCENTILE` and `PERCENTILE.INC`, Python `'inclusive'`)
-Def. 8: α=1//3, β=1//3
-Def. 9: α=3//8, β=3//8
+- Def. 7: `α=1`, `β=1` (Julia, R and NumPy default, Excel `PERCENTILE` and `PERCENTILE.INC`, Python `'inclusive'`)
+- Def. 8: `α=1/3`, `β=1/3`
+- Def. 9: `α=3/8`, `β=3/8`
 
 !!! note
     An `ArgumentError` is thrown if `v` contains `NaN` or [`missing`](@ref) values.
@@ -898,7 +898,7 @@ function quantile!(q::AbstractArray, v::AbstractVector, p::AbstractArray;
 end
 
 function quantile!(v::AbstractVector, p::Union{AbstractArray, Tuple{Vararg{Real}}};
-                   sorted::Bool=false, α=1, β=α)
+                   sorted::Bool=false, α::Real=1, β::Real=α)
     if !isempty(p)
         minp, maxp = extrema(p)
         _quantilesort!(v, sorted, minp, maxp)
@@ -906,7 +906,7 @@ function quantile!(v::AbstractVector, p::Union{AbstractArray, Tuple{Vararg{Real}
     return map(x->_quantile(v, x, α=α, β=β), p)
 end
 
-quantile!(v::AbstractVector, p::Real; sorted::Bool=false, α=1, β=α) =
+quantile!(v::AbstractVector, p::Real; sorted::Bool=false, α::Real=1, β::Real=α) =
     _quantile(_quantilesort!(v, sorted, p, p), p, α=α, β=β)
 
 # Function to perform partial sort of v for quantiles in given range
@@ -930,7 +930,7 @@ function _quantilesort!(v::AbstractArray, sorted::Bool, minp::Real, maxp::Real)
 end
 
 # Core quantile lookup function: assumes `v` sorted
-@inline function _quantile(v::AbstractVector, p::Real; α=1, β=α)
+@inline function _quantile(v::AbstractVector, p::Real; α::Real=1, β::Real=α)
     0 <= p <= 1 || throw(ArgumentError("input probability out of [0,1] range"))
     0 <= α <= 1 || throw(ArgumentError("α parameter out of [0,1] range"))
     0 <= β <= 1 || throw(ArgumentError("β parameter out of [0,1] range"))
@@ -963,7 +963,7 @@ end
 end
 
 """
-    quantile(itr, p; sorted=false, α=1, β=α)
+    quantile(itr, p; sorted=false, α::Real=1, β::Real=α)
 
 Compute the quantile(s) of a collection `itr` at a specified probability or vector or tuple of
 probabilities `p` on the interval [0,1]. The keyword argument `sorted` indicates whether
@@ -982,12 +982,12 @@ The keyword parameters α and β correspond to the same parameters in Hyndman an
 setting them to different values allows to calculate quantiles with any of the methods 4-9
 defined in this paper:
 
-Def. 4: α=0, β=1
-Def. 5: α=0.5, β=0.5
-Def. 6: α=0, β=0 (Excel PERCENTILE.EXC, Python exclusive-method)
-Def. 7: α=1, β=1 (Julia default, Excel PERCENTILE.INC, Python inclusive-method)
-Def. 8: α=1//3, β=1//3
-Def. 9: α=3//8, β=3//8
+- Def. 4: `α=0`, `β=1`
+- Def. 5: `α=0.5`, `β=0.5`
+- Def. 6: `α=0`, `β=0` (Excel `PERCENTILE.EXC`, Python default, Stata `altdef`)
+- Def. 7: `α=1`, `β=1` (Julia, R and NumPy default, Excel `PERCENTILE` and `PERCENTILE.INC`, Python `'inclusive'`)
+- Def. 8: `α=1/3`, `β=1/3`
+- Def. 9: `α=3/8`, `β=3/8`
 
 !!! note
     An `ArgumentError` is thrown if `v` contains `NaN` or [`missing`](@ref) values.
@@ -1010,9 +1010,9 @@ julia> quantile(skipmissing([1, 10, missing]), 0.5)
 5.5
 ```
 """
-quantile(itr, p; sorted::Bool=false, α=1, β=α) = quantile!(collect(itr), p, sorted=sorted, α=α, β=β)
+quantile(itr, p; sorted::Bool=false, α::Real=1, β::Real=α) = quantile!(collect(itr), p, sorted=sorted, α=α, β=β)
 
-quantile(v::AbstractVector, p; sorted::Bool=false, α=1, β=α) =
+quantile(v::AbstractVector, p; sorted::Bool=false, α::Real=1, β::Real=α) =
     quantile!(sorted ? v : Base.copymutable(v), p; sorted=sorted, α=α, β=β)
 
 

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -887,9 +887,9 @@ true
 
 julia> y
 3-element Array{Float64,1}:
- 1.2
+ 1.2000000000000002
  2.0
- 2.8
+ 2.8000000000000003
 ```
 """
 function quantile!(q::AbstractArray, v::AbstractVector, p::AbstractArray;
@@ -1008,7 +1008,7 @@ julia> quantile(0:20, [0.1, 0.5, 0.9])
 3-element Array{Float64,1}:
   2.0
  10.0
- 18.0
+ 18.000000000000004
 
 julia> quantile(skipmissing([1, 10, missing]), 0.5)
 5.5

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -1000,11 +1000,13 @@ defined in this paper:
 ```jldoctest
 julia> quantile(0:20, 0.5)
 10.0
+
 julia> quantile(0:20, [0.1, 0.5, 0.9])
 3-element Array{Float64,1}:
   2.0
  10.0
  18.0
+ 
 julia> quantile(skipmissing([1, 10, missing]), 0.5)
 5.5
 ```

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -845,7 +845,7 @@ where ``x[j]`` is the j-th order statistic, and `γ` is a function of
 `j = floor(n*p + m)`, `m = alpha + p*(1 - alpha - beta)` and
 `g = n*p + m - j`.
 
-As default (alpha=1, beta=alpha), quantiles are computed via linear interpolation between the points
+By default (`alpha = beta = 1`), quantiles are computed via linear interpolation between the points
 `((k-1)/(n-1), v[k])`, for `k = 1:n` where `n = length(itr)`. This corresponds to Definition 7
  of Hyndman and Fan (1996), and is the same as the R and NumPy default.
 

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -966,7 +966,7 @@ end
 end
 
 """
-    quantile(itr, p; sorted=false, alpha::Real=1., beta::Real=alpha)
+    quantile(itr, p; sorted=false, alpha::Real=1.0, beta::Real=alpha)
 
 Compute the quantile(s) of a collection `itr` at a specified probability or vector or tuple of
 probabilities `p` on the interval [0,1]. The keyword argument `sorted` indicates whether

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -951,7 +951,7 @@ end
 
     n = length(v)
     m = alpha + p * (one(alpha) - alpha - beta)
-    aleph = n*p + m
+    aleph = n*p + oftype(p, m)
     j = clamp(trunc(Int, aleph), 1, n-1)
     γ = clamp(aleph - j, 0, 1)
 

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -831,7 +831,7 @@ where ``x[j]`` is the j-th order statistic, and γ is a function of
 ``j = floor(n*p + m)``, ``m = α + p*(1 - α - β)`` and
 ``g = n*p + m - j``.
 
-As default (α=1, β=α), quantiles are computed via linear interpolation between the points `((k-1)/(n-1), v[k])`,
+By default (`α = β = 1`), quantiles are computed via linear interpolation between the points `((k-1)/(n-1), v[k])`,
 for `k = 1:n` where `n = length(v)`. This corresponds to Definition 7 of Hyndman and Fan
 (1996), and is the same as the R default.
 

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -881,7 +881,7 @@ julia> y
 ```
 """
 function quantile!(q::AbstractArray, v::AbstractVector, p::AbstractArray;
-                   sorted::Bool=false, α=1, β=α)
+                   sorted::Bool=false, α::Real=1, β::Real=α)
     require_one_based_indexing(q, v, p)
     if size(p) != size(q)
         throw(DimensionMismatch("size of p, $(size(p)), must equal size of q, $(size(q))"))

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -833,27 +833,23 @@ _median(v::AbstractArray, dims) = mapslices(median!, v, dims = dims)
 
 _median(v::AbstractArray{T}, ::Colon) where {T} = median!(copyto!(Array{T,1}(undef, length(v)), v))
 
-# for now, use the R/S definition of quantile; may want variants later
-# see ?quantile in R -- this is type 7
 """
     quantile!([q::AbstractArray, ] v::AbstractVector, p; sorted=false, alpha::Real=1., beta::Real=alpha)
 
-Compute the quantile(s) of a vector `v` at a specified probability or vector or tuple of
-probabilities `p` on the interval [0,1]. If `p` is a vector, an optional
-output array `q` may also be specified. (If not provided, a new output array is created.)
-The keyword argument `sorted` indicates whether `v` can be assumed to be sorted; if
-`false` (the default), then the elements of `v` will be partially sorted in-place.
+Compute the quantile(s) of a collection `itr` at a specified probability or vector or tuple of
+probabilities `p` on the interval [0,1]. The keyword argument `sorted` indicates whether
+`itr` can be assumed to be sorted.
 
 Samples quantile are defined by `Q(p) = (1-γ)*x[j] + γ*x[j+1]`,
-where `x[j]` is the j-th order statistic, and `γ` is a function of
+where ``x[j]`` is the j-th order statistic, and `γ` is a function of
 `j = floor(n*p + m)`, `m = alpha + p*(1 - alpha - beta)` and
 `g = n*p + m - j`.
 
-By default (`alpha = beta = 1`), quantiles are computed via linear interpolation between the points
-`((k-1)/(n-1), v[k])`, for `k = 1:n` where `n = length(v)`. This corresponds to Definition 7
-of Hyndman and Fan (1996), and is the same as the R and NumPy default.
+As default (alpha=1, beta=alpha), quantiles are computed via linear interpolation between the points
+`((k-1)/(n-1), v[k])`, for `k = 1:n` where `n = length(itr)`. This corresponds to Definition 7
+ of Hyndman and Fan (1996), and is the same as the R and NumPy default.
 
-The keyword arguments `alpha` and `beta` correspond to the same parameters as in Hyndman and Fan,
+The keyword parameters alpha and beta correspond to the same parameters in Hyndman and Fan,
 setting them to different values allows to calculate quantiles with any of the methods 4-9
 defined in this paper:
 - Def. 4: `alpha=0`, `beta=1`
@@ -935,8 +931,6 @@ function _quantilesort!(v::AbstractArray, sorted::Bool, minp::Real, maxp::Real)
 
     if !sorted
         lv = length(v)
-        # if not alpha==1 && beta==1, we need to increase the sort range a bit, otherwise we may get wrong results
-        # for performance reasons, this is not done for standard alpha and beta
         lo = floor(Int,minp*(lv))
         hi = ceil(Int,1+maxp*(lv))
 
@@ -1023,7 +1017,8 @@ julia> quantile(skipmissing([1, 10, missing]), 0.5)
 5.5
 ```
 """
-quantile(itr, p; sorted::Bool=false, alpha::Real=1., beta::Real=alpha) = quantile!(collect(itr), p, sorted=sorted, alpha=alpha, beta=beta)
+quantile(itr, p; sorted::Bool=false, alpha::Real=1., beta::Real=alpha) =
+    quantile!(collect(itr), p, sorted=sorted, alpha=alpha, beta=beta)
 
 quantile(v::AbstractVector, p; sorted::Bool=false, alpha::Real=1., beta::Real=alpha) =
     quantile!(sorted ? v : Base.copymutable(v), p; sorted=sorted, alpha=alpha, beta=beta)

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -835,7 +835,7 @@ By default (`α = β = 1`), quantiles are computed via linear interpolation betw
 for `k = 1:n` where `n = length(v)`. This corresponds to Definition 7 of Hyndman and Fan
 (1996), and is the same as the R default.
 
-The keyword parameters α and β correspond to the same parameters in Hyndman and Fan,
+The keyword arguments `α` and `β` correspond to the same parameters as in Hyndman and Fan,
 setting them to different values allows to calculate quantiles with any of the methods 4-9
 defined in this paper:
 

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -841,7 +841,7 @@ defined in this paper:
 
 - Def. 4: `α=0`, `β=1`
 Def. 5: α=0.5, β=0.5
-Def. 6: α=0, β=0 (Excel PERCENTILE.EXC, Python exclusive-method)
+- Def. 6: `α=0`, `β=0` (Excel `PERCENTILE.EXC`, Python default, Stata `altdef`)
 Def. 7: α=1, β=1 (Julia, R and NumPy default, Excel `PERCENTILE` and `PERCENTILE.INC`, Python `'inclusive'`)
 Def. 8: α=1//3, β=1//3
 Def. 9: α=3//8, β=3//8

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -826,19 +826,18 @@ output array `q` may also be specified. (If not provided, a new output array is 
 The keyword argument `sorted` indicates whether `v` can be assumed to be sorted; if
 `false` (the default), then the elements of `v` will be partially sorted in-place.
 
-Samples quantile are defined by ``Q(p) = (1-γ)*x[j] + γ*x[j+1]``,
-where ``x[j]`` is the j-th order statistic, and γ is a function of
-``j = floor(n*p + m)``, ``m = α + p*(1 - α - β)`` and
-``g = n*p + m - j``.
+Samples quantile are defined by `Q(p) = (1-γ)*x[j] + γ*x[j+1]`,
+where `x[j]` is the j-th order statistic, and `γ` is a function of
+`j = floor(n*p + m)`, `m = α + p*(1 - α - β)` and
+`g = n*p + m - j`.
 
-By default (`α = β = 1`), quantiles are computed via linear interpolation between the points `((k-1)/(n-1), v[k])`,
-for `k = 1:n` where `n = length(v)`. This corresponds to Definition 7 of Hyndman and Fan
-(1996), and is the same as the R default.
+By default (`α = β = 1`), quantiles are computed via linear interpolation between the points
+`((k-1)/(n-1), v[k])`, for `k = 1:n` where `n = length(v)`. This corresponds to Definition 7
+of Hyndman and Fan (1996), and is the same as the R and NumPy default.
 
 The keyword arguments `α` and `β` correspond to the same parameters as in Hyndman and Fan,
 setting them to different values allows to calculate quantiles with any of the methods 4-9
 defined in this paper:
-
 - Def. 4: `α=0`, `β=1`
 - Def. 5: `α=0.5`, `β=0.5`
 - Def. 6: `α=0`, `β=0` (Excel `PERCENTILE.EXC`, Python default, Stata `altdef`)
@@ -849,11 +848,11 @@ defined in this paper:
 !!! note
     An `ArgumentError` is thrown if `v` contains `NaN` or [`missing`](@ref) values.
 
-* Hyndman, R.J and Fan, Y. (1996) "Sample Quantiles in Statistical Packages",
+# References
+- Hyndman, R.J and Fan, Y. (1996) "Sample Quantiles in Statistical Packages",
   *The American Statistician*, Vol. 50, No. 4, pp. 361-365
 
-* [Quantile on Wikipedia](https://en.m.wikipedia.org/wiki/Quantile) details the different quantile definitions
-
+- [Quantile on Wikipedia](https://en.m.wikipedia.org/wiki/Quantile) details the different quantile definitions
 
 # Examples
 ```jldoctest
@@ -969,19 +968,18 @@ Compute the quantile(s) of a collection `itr` at a specified probability or vect
 probabilities `p` on the interval [0,1]. The keyword argument `sorted` indicates whether
 `itr` can be assumed to be sorted.
 
-Samples quantile are defined by ``Q(p) = (1-γ)*x[j] + γ*x[j+1]``,
-where ``x[j]`` is the j-th order statistic, and γ is a function of
-``j = floor(n*p + m)``, ``m = α + p*(1 - α - β)`` and
-``g = n*p + m - j``.
+Samples quantile are defined by `Q(p) = (1-γ)*x[j] + γ*x[j+1]`,
+where ``x[j]`` is the j-th order statistic, and `γ` is a function of
+`j = floor(n*p + m)`, `m = α + p*(1 - α - β)` and
+`g = n*p + m - j`.
 
-As default (α=1, β=α), quantiles are computed via linear interpolation between the points `((k-1)/(n-1), v[k])`,
-for `k = 1:n` where `n = length(itr)`. This corresponds to Definition 7 of Hyndman and Fan
-(1996), and is the same as the R default.
+As default (α=1, β=α), quantiles are computed via linear interpolation between the points
+`((k-1)/(n-1), v[k])`, for `k = 1:n` where `n = length(itr)`. This corresponds to Definition 7
+ of Hyndman and Fan (1996), and is the same as the R and NumPy default.
 
 The keyword parameters α and β correspond to the same parameters in Hyndman and Fan,
 setting them to different values allows to calculate quantiles with any of the methods 4-9
 defined in this paper:
-
 - Def. 4: `α=0`, `β=1`
 - Def. 5: `α=0.5`, `β=0.5`
 - Def. 6: `α=0`, `β=0` (Excel `PERCENTILE.EXC`, Python default, Stata `altdef`)
@@ -992,10 +990,11 @@ defined in this paper:
 !!! note
     An `ArgumentError` is thrown if `v` contains `NaN` or [`missing`](@ref) values.
 
-* Hyndman, R.J and Fan, Y. (1996) "Sample Quantiles in Statistical Packages",
+# References
+- Hyndman, R.J and Fan, Y. (1996) "Sample Quantiles in Statistical Packages",
   *The American Statistician*, Vol. 50, No. 4, pp. 361-365
 
-* https://en.m.wikipedia.org/wiki/Quantile
+- [Quantile on Wikipedia](https://en.m.wikipedia.org/wiki/Quantile) details the different quantile definitions
 
 # Examples
 ```jldoctest

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -846,7 +846,7 @@ where ``x[j]`` is the j-th order statistic, and `γ` is a function of
 `g = n*p + m - j`.
 
 By default (`alpha = beta = 1`), quantiles are computed via linear interpolation between the points
-`((k-1)/(n-1), v[k])`, for `k = 1:n` where `n = length(itr)`. This corresponds to Definition 7
+`((k-1)/(n-1), v[k])`, for `k = 1:n` where `n = length(v)`. This corresponds to Definition 7
  of Hyndman and Fan (1996), and is the same as the R and NumPy default.
 
 The keyword parameters alpha and beta correspond to the same parameters in Hyndman and Fan,

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -836,14 +836,11 @@ _median(v::AbstractArray{T}, ::Colon) where {T} = median!(copyto!(Array{T,1}(und
 """
     quantile!([q::AbstractArray, ] v::AbstractVector, p; sorted=false, alpha::Real=1.0, beta::Real=alpha)
 
-Compute the quantile(s) of a collection `itr` at a specified probability or vector or tuple of
-probabilities `p` on the interval [0,1]. The keyword argument `sorted` indicates whether
-`itr` can be assumed to be sorted.
-
-Samples quantile are defined by `Q(p) = (1-γ)*x[j] + γ*x[j+1]`,
-where ``x[j]`` is the j-th order statistic, and `γ` is a function of
-`j = floor(n*p + m)`, `m = alpha + p*(1 - alpha - beta)` and
-`g = n*p + m - j`.
+Compute the quantile(s) of a vector `v` at a specified probability or vector or tuple of
+probabilities `p` on the interval [0,1]. If `p` is a vector, an optional
+output array `q` may also be specified. (If not provided, a new output array is created.)
+The keyword argument `sorted` indicates whether `v` can be assumed to be sorted; if
+`false` (the default), then the elements of `v` will be partially sorted in-place.
 
 By default (`alpha = beta = 1`), quantiles are computed via linear interpolation between the points
 `((k-1)/(n-1), v[k])`, for `k = 1:n` where `n = length(v)`. This corresponds to Definition 7
@@ -896,7 +893,7 @@ julia> y
 ```
 """
 function quantile!(q::AbstractArray, v::AbstractVector, p::AbstractArray;
-                   sorted::Bool=false, alpha::Real=1., beta::Real=alpha)
+                   sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha)
     require_one_based_indexing(q, v, p)
     if size(p) != size(q)
         throw(DimensionMismatch("size of p, $(size(p)), must equal size of q, $(size(q))"))
@@ -943,7 +940,7 @@ function _quantilesort!(v::AbstractArray, sorted::Bool, minp::Real, maxp::Real)
 end
 
 # Core quantile lookup function: assumes `v` sorted
-@inline function _quantile(v::AbstractVector, p::Real; alpha::Real=1., beta::Real=alpha)
+@inline function _quantile(v::AbstractVector, p::Real; alpha::Real=1.0, beta::Real=alpha)
     0 <= p <= 1 || throw(ArgumentError("input probability out of [0,1] range"))
     0 <= alpha <= 1 || throw(ArgumentError("alpha parameter out of [0,1] range"))
     0 <= beta <= 1 || throw(ArgumentError("beta parameter out of [0,1] range"))
@@ -1017,10 +1014,10 @@ julia> quantile(skipmissing([1, 10, missing]), 0.5)
 5.5
 ```
 """
-quantile(itr, p; sorted::Bool=false, alpha::Real=1., beta::Real=alpha) =
+quantile(itr, p; sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
     quantile!(collect(itr), p, sorted=sorted, alpha=alpha, beta=beta)
 
-quantile(v::AbstractVector, p; sorted::Bool=false, alpha::Real=1., beta::Real=alpha) =
+quantile(v::AbstractVector, p; sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
     quantile!(sorted ? v : Base.copymutable(v), p; sorted=sorted, alpha=alpha, beta=beta)
 
 

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -839,7 +839,7 @@ The keyword arguments `α` and `β` correspond to the same parameters as in Hynd
 setting them to different values allows to calculate quantiles with any of the methods 4-9
 defined in this paper:
 
-Def. 4: α=0, β=1
+- Def. 4: `α=0`, `β=1`
 Def. 5: α=0.5, β=0.5
 Def. 6: α=0, β=0 (Excel PERCENTILE.EXC, Python exclusive-method)
 Def. 7: α=1, β=1 (Julia default, Excel PERCENTILE.INC, Python inclusive-method)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-using Statistics,
-using Test, Random, LinearAlgebra, SparseArrays
+using Statistics, Test, Random, LinearAlgebra, SparseArrays
 using Test: guardseed
 
 Random.seed!(123)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -489,7 +489,7 @@ end
     @test quantile(100f0:-1f0:0.0, 0.0:0.1:1.0) ≈ 0f0:10f0:100f0
     @test quantile([Inf,Inf],0.5) == Inf
     @test quantile([-Inf,1],0.5) == -Inf
-    # here it is required to introduce an absolute tolerance because the calculated value is 0 in the method with parameters alpha and beta
+    # here it is required to introduce an absolute tolerance because the calculated value is 0
     @test quantile([0,1],1e-18) ≈ 1e-18 atol=1e-18
     @test quantile([1, 2, 3, 4],[]) == []
     @test quantile([1, 2, 3, 4], (0.5,)) == (2.5,)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -536,96 +536,87 @@ end
     @test y == [1.2, 2.0, 2.8]
 
     #tests for quantile calculation with configurable α and β parameters
-    let v = [2, 3, 4, 6, 9, 2, 6, 2, 21, 17]
-        # consistency to standard quantile method
-        @test quantile(v, 0.7) ≈ quantile(v, 0.7, 1, 1)
-        @test quantile(v, 0.99) ≈ quantile(v, 0.99, 1, 1)
+    v = [2, 3, 4, 6, 9, 2, 6, 2, 21, 17]
 
-        # tests against SciPy quantile method
-        @test quantile(v, 0.0, 0.0, 0.0) ≈ 2.0
-        @test quantile(v, 0.2, 1.0, 1.0) ≈ 2.0
-        @test quantile(v, 0.4, 0.0, 0.0) ≈ 3.4000000000000004
-        @test quantile(v, 0.4, 0.0, 0.2) ≈ 3.3200000000000003
-        @test quantile(v, 0.4, 0.0, 0.4) ≈ 3.24
-        @test quantile(v, 0.4, 0.0, 0.6) ≈ 3.16
-        @test quantile(v, 0.4, 0.0, 0.8) ≈ 3.08
-        @test quantile(v, 0.4, 0.0, 1.0) ≈ 3.0
-        @test quantile(v, 0.4, 0.2, 0.0) ≈ 3.5199999999999996
-        @test quantile(v, 0.4, 0.2, 0.2) ≈ 3.4400000000000004
-        @test quantile(v, 0.4, 0.2, 0.4) ≈ 3.3600000000000003
-        @test quantile(v, 0.4, 0.2, 0.6) ≈ 3.2800000000000002
-        @test quantile(v, 0.4, 0.2, 0.8) ≈ 3.2
-        @test quantile(v, 0.4, 0.2, 1.0) ≈ 3.12
-        @test quantile(v, 0.4, 0.4, 0.0) ≈ 3.6399999999999997
-        @test quantile(v, 0.4, 0.4, 0.2) ≈ 3.5600000000000005
-        @test quantile(v, 0.4, 0.4, 0.4) ≈ 3.4800000000000004
-        @test quantile(v, 0.4, 0.4, 0.6) ≈ 3.4000000000000004
-        @test quantile(v, 0.4, 0.4, 0.8) ≈ 3.3200000000000003
-        @test quantile(v, 0.4, 0.4, 1.0) ≈ 3.24
-        @test quantile(v, 0.4, 0.6, 0.0) ≈ 3.76
-        @test quantile(v, 0.4, 0.6, 0.2) ≈ 3.6799999999999997
-        @test quantile(v, 0.4, 0.6, 0.4) ≈ 3.5999999999999996
-        @test quantile(v, 0.4, 0.6, 0.6) ≈ 3.5199999999999996
-        @test quantile(v, 0.4, 0.6, 0.8) ≈ 3.4399999999999995
-        @test quantile(v, 0.4, 0.6, 1.0) ≈ 3.3600000000000003
-        @test quantile(v, 0.4, 0.8, 0.0) ≈ 3.88
-        @test quantile(v, 0.4, 0.8, 0.2) ≈ 3.8
-        @test quantile(v, 0.4, 0.8, 0.4) ≈ 3.7199999999999998
-        @test quantile(v, 0.4, 0.8, 0.6) ≈ 3.6399999999999997
-        @test quantile(v, 0.4, 0.8, 0.8) ≈ 3.5600000000000005
-        @test quantile(v, 0.4, 0.8, 1.0) ≈ 3.4800000000000004
-        @test quantile(v, 0.4, 1.0, 0.0) ≈ 4.0
-        @test quantile(v, 0.4, 1.0, 0.2) ≈ 3.92
-        @test quantile(v, 0.4, 1.0, 0.4) ≈ 3.84
-        @test quantile(v, 0.4, 1.0, 0.6) ≈ 3.76
-        @test quantile(v, 0.4, 1.0, 0.8) ≈ 3.6799999999999997
-        @test quantile(v, 0.4, 1.0, 1.0) ≈ 3.5999999999999996
-        @test quantile(v, 0.6, 0.0, 0.0) ≈ 6.0
-        @test quantile(v, 0.6, 1.0, 1.0) ≈ 6.0
-        @test quantile(v, 0.8, 0.0, 0.0) ≈ 15.400000000000006
-        @test quantile(v, 0.8, 0.0, 0.2) ≈ 14.120000000000005
-        @test quantile(v, 0.8, 0.0, 0.4) ≈ 12.840000000000003
-        @test quantile(v, 0.8, 0.0, 0.6) ≈ 11.560000000000002
-        @test quantile(v, 0.8, 0.0, 0.8) ≈ 10.280000000000001
-        @test quantile(v, 0.8, 0.0, 1.0) ≈ 9.0
-        @test quantile(v, 0.8, 0.2, 0.0) ≈ 15.719999999999999
-        @test quantile(v, 0.8, 0.2, 0.2) ≈ 14.439999999999998
-        @test quantile(v, 0.8, 0.2, 0.4) ≈ 13.159999999999997
-        @test quantile(v, 0.8, 0.2, 0.6) ≈ 11.879999999999995
-        @test quantile(v, 0.8, 0.2, 0.8) ≈ 10.599999999999994
-        @test quantile(v, 0.8, 0.2, 1.0) ≈ 9.319999999999993
-        @test quantile(v, 0.8, 0.4, 0.0) ≈ 16.040000000000006
-        @test quantile(v, 0.8, 0.4, 0.2) ≈ 14.760000000000005
-        @test quantile(v, 0.8, 0.4, 0.4) ≈ 13.480000000000004
-        @test quantile(v, 0.8, 0.4, 0.6) ≈ 12.200000000000003
-        @test quantile(v, 0.8, 0.4, 0.8) ≈ 10.920000000000002
-        @test quantile(v, 0.8, 0.4, 1.0) ≈ 9.64
-        @test quantile(v, 0.8, 0.6, 0.0) ≈ 16.36
-        @test quantile(v, 0.8, 0.6, 0.2) ≈ 15.079999999999998
-        @test quantile(v, 0.8, 0.6, 0.4) ≈ 13.799999999999997
-        @test quantile(v, 0.8, 0.6, 0.6) ≈ 12.519999999999996
-        @test quantile(v, 0.8, 0.6, 0.8) ≈ 11.239999999999995
-        @test quantile(v, 0.8, 0.6, 1.0) ≈ 9.959999999999994
-        @test quantile(v, 0.8, 0.8, 0.0) ≈ 16.680000000000007
-        @test quantile(v, 0.8, 0.8, 0.2) ≈ 15.400000000000006
-        @test quantile(v, 0.8, 0.8, 0.4) ≈ 14.120000000000005
-        @test quantile(v, 0.8, 0.8, 0.6) ≈ 12.840000000000003
-        @test quantile(v, 0.8, 0.8, 0.8) ≈ 11.560000000000002
-        @test quantile(v, 0.8, 0.8, 1.0) ≈ 10.280000000000001
-        @test quantile(v, 0.8, 1.0, 0.0) ≈ 17.0
-        @test quantile(v, 0.8, 1.0, 0.2) ≈ 15.719999999999999
-        @test quantile(v, 0.8, 1.0, 0.4) ≈ 14.439999999999998
-        @test quantile(v, 0.8, 1.0, 0.6) ≈ 13.159999999999997
-        @test quantile(v, 0.8, 1.0, 0.8) ≈ 11.879999999999995
-        @test quantile(v, 0.8, 1.0, 1.0) ≈ 10.599999999999994
-        @test quantile(v, 1.0, 0.0, 0.0) ≈ 21.0
-        @test quantile(v, 1.0, 1.0, 1.0) ≈ 21.0
-
-
-    end
-
-
-
+    # tests against SciPy quantile method
+    @test quantile(v, 0.0, α=0.0, β=0.0) ≈ 2.0
+    @test quantile(v, 0.2, α=1.0, β=1.0) ≈ 2.0
+    @test quantile(v, 0.4, α=0.0, β=0.0) ≈ 3.4000000000000004
+    @test quantile(v, 0.4, α=0.0, β=0.2) ≈ 3.3200000000000003
+    @test quantile(v, 0.4, α=0.0, β=0.4) ≈ 3.24
+    @test quantile(v, 0.4, α=0.0, β=0.6) ≈ 3.16
+    @test quantile(v, 0.4, α=0.0, β=0.8) ≈ 3.08
+    @test quantile(v, 0.4, α=0.0, β=1.0) ≈ 3.0
+    @test quantile(v, 0.4, α=0.2, β=0.0) ≈ 3.5199999999999996
+    @test quantile(v, 0.4, α=0.2, β=0.2) ≈ 3.4400000000000004
+    @test quantile(v, 0.4, α=0.2, β=0.4) ≈ 3.3600000000000003
+    @test quantile(v, 0.4, α=0.2, β=0.6) ≈ 3.2800000000000002
+    @test quantile(v, 0.4, α=0.2, β=0.8) ≈ 3.2
+    @test quantile(v, 0.4, α=0.2, β=1.0) ≈ 3.12
+    @test quantile(v, 0.4, α=0.4, β=0.0) ≈ 3.6399999999999997
+    @test quantile(v, 0.4, α=0.4, β=0.2) ≈ 3.5600000000000005
+    @test quantile(v, 0.4, α=0.4, β=0.4) ≈ 3.4800000000000004
+    @test quantile(v, 0.4, α=0.4, β=0.6) ≈ 3.4000000000000004
+    @test quantile(v, 0.4, α=0.4, β=0.8) ≈ 3.3200000000000003
+    @test quantile(v, 0.4, α=0.4, β=1.0) ≈ 3.24
+    @test quantile(v, 0.4, α=0.6, β=0.0) ≈ 3.76
+    @test quantile(v, 0.4, α=0.6, β=0.2) ≈ 3.6799999999999997
+    @test quantile(v, 0.4, α=0.6, β=0.4) ≈ 3.5999999999999996
+    @test quantile(v, 0.4, α=0.6, β=0.6) ≈ 3.5199999999999996
+    @test quantile(v, 0.4, α=0.6, β=0.8) ≈ 3.4399999999999995
+    @test quantile(v, 0.4, α=0.6, β=1.0) ≈ 3.3600000000000003
+    @test quantile(v, 0.4, α=0.8, β=0.0) ≈ 3.88
+    @test quantile(v, 0.4, α=0.8, β=0.2) ≈ 3.8
+    @test quantile(v, 0.4, α=0.8, β=0.4) ≈ 3.7199999999999998
+    @test quantile(v, 0.4, α=0.8, β=0.6) ≈ 3.6399999999999997
+    @test quantile(v, 0.4, α=0.8, β=0.8) ≈ 3.5600000000000005
+    @test quantile(v, 0.4, α=0.8, β=1.0) ≈ 3.4800000000000004
+    @test quantile(v, 0.4, α=1.0, β=0.0) ≈ 4.0
+    @test quantile(v, 0.4, α=1.0, β=0.2) ≈ 3.92
+    @test quantile(v, 0.4, α=1.0, β=0.4) ≈ 3.84
+    @test quantile(v, 0.4, α=1.0, β=0.6) ≈ 3.76
+    @test quantile(v, 0.4, α=1.0, β=0.8) ≈ 3.6799999999999997
+    @test quantile(v, 0.4, α=1.0, β=1.0) ≈ 3.5999999999999996
+    @test quantile(v, 0.6, α=0.0, β=0.0) ≈ 6.0
+    @test quantile(v, 0.6, α=1.0, β=1.0) ≈ 6.0
+    @test quantile(v, 0.8, α=0.0, β=0.0) ≈ 15.400000000000006
+    @test quantile(v, 0.8, α=0.0, β=0.2) ≈ 14.120000000000005
+    @test quantile(v, 0.8, α=0.0, β=0.4) ≈ 12.840000000000003
+    @test quantile(v, 0.8, α=0.0, β=0.6) ≈ 11.560000000000002
+    @test quantile(v, 0.8, α=0.0, β=0.8) ≈ 10.280000000000001
+    @test quantile(v, 0.8, α=0.0, β=1.0) ≈ 9.0
+    @test quantile(v, 0.8, α=0.2, β=0.0) ≈ 15.719999999999999
+    @test quantile(v, 0.8, α=0.2, β=0.2) ≈ 14.439999999999998
+    @test quantile(v, 0.8, α=0.2, β=0.4) ≈ 13.159999999999997
+    @test quantile(v, 0.8, α=0.2, β=0.6) ≈ 11.879999999999995
+    @test quantile(v, 0.8, α=0.2, β=0.8) ≈ 10.599999999999994
+    @test quantile(v, 0.8, α=0.2, β=1.0) ≈ 9.319999999999993
+    @test quantile(v, 0.8, α=0.4, β=0.0) ≈ 16.040000000000006
+    @test quantile(v, 0.8, α=0.4, β=0.2) ≈ 14.760000000000005
+    @test quantile(v, 0.8, α=0.4, β=0.4) ≈ 13.480000000000004
+    @test quantile(v, 0.8, α=0.4, β=0.6) ≈ 12.200000000000003
+    @test quantile(v, 0.8, α=0.4, β=0.8) ≈ 10.920000000000002
+    @test quantile(v, 0.8, α=0.4, β=1.0) ≈ 9.64
+    @test quantile(v, 0.8, α=0.6, β=0.0) ≈ 16.36
+    @test quantile(v, 0.8, α=0.6, β=0.2) ≈ 15.079999999999998
+    @test quantile(v, 0.8, α=0.6, β=0.4) ≈ 13.799999999999997
+    @test quantile(v, 0.8, α=0.6, β=0.6) ≈ 12.519999999999996
+    @test quantile(v, 0.8, α=0.6, β=0.8) ≈ 11.239999999999995
+    @test quantile(v, 0.8, α=0.6, β=1.0) ≈ 9.959999999999994
+    @test quantile(v, 0.8, α=0.8, β=0.0) ≈ 16.680000000000007
+    @test quantile(v, 0.8, α=0.8, β=0.2) ≈ 15.400000000000006
+    @test quantile(v, 0.8, α=0.8, β=0.4) ≈ 14.120000000000005
+    @test quantile(v, 0.8, α=0.8, β=0.6) ≈ 12.840000000000003
+    @test quantile(v, 0.8, α=0.8, β=0.8) ≈ 11.560000000000002
+    @test quantile(v, 0.8, α=0.8, β=1.0) ≈ 10.280000000000001
+    @test quantile(v, 0.8, α=1.0, β=0.0) ≈ 17.0
+    @test quantile(v, 0.8, α=1.0, β=0.2) ≈ 15.719999999999999
+    @test quantile(v, 0.8, α=1.0, β=0.4) ≈ 14.439999999999998
+    @test quantile(v, 0.8, α=1.0, β=0.6) ≈ 13.159999999999997
+    @test quantile(v, 0.8, α=1.0, β=0.8) ≈ 11.879999999999995
+    @test quantile(v, 0.8, α=1.0, β=1.0) ≈ 10.599999999999994
+    @test quantile(v, 1.0, α=0.0, β=0.0) ≈ 21.0
+    @test quantile(v, 1.0, α=1.0, β=1.0) ≈ 21.0
 end
 
 # StatsBase issue 164

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -580,40 +580,6 @@ end
     @test quantile(v, 0.4, α=1.0, β=0.8) ≈ 3.68
     @test quantile(v, 0.4, α=1.0, β=1.0) ≈ 3.6
     @test quantile(v, 0.6, α=0.0, β=0.0) ≈ 6.0
-    @test quantile(v, 0.6, α=0.0, β=0.2) ≈ 6.0
-    @test quantile(v, 0.6, α=0.0, β=0.4) ≈ 6.0
-    @test quantile(v, 0.6, α=0.0, β=0.6) ≈ 6.0
-    @test quantile(v, 0.6, α=0.0, β=0.8) ≈ 6.0
-    @test quantile(v, 0.6, α=0.0, β=1.0) ≈ 6.0
-    @test quantile(v, 0.6, α=0.2, β=0.0) ≈ 6.0
-    @test quantile(v, 0.6, α=0.2, β=0.2) ≈ 6.0
-    @test quantile(v, 0.6, α=0.2, β=0.4) ≈ 6.0
-    @test quantile(v, 0.6, α=0.2, β=0.6) ≈ 6.0
-    @test quantile(v, 0.6, α=0.2, β=0.8) ≈ 6.0
-    @test quantile(v, 0.6, α=0.2, β=1.0) ≈ 6.0
-    @test quantile(v, 0.6, α=0.4, β=0.0) ≈ 6.0
-    @test quantile(v, 0.6, α=0.4, β=0.2) ≈ 6.0
-    @test quantile(v, 0.6, α=0.4, β=0.4) ≈ 6.0
-    @test quantile(v, 0.6, α=0.4, β=0.6) ≈ 6.0
-    @test quantile(v, 0.6, α=0.4, β=0.8) ≈ 6.0
-    @test quantile(v, 0.6, α=0.4, β=1.0) ≈ 6.0
-    @test quantile(v, 0.6, α=0.6, β=0.0) ≈ 6.0
-    @test quantile(v, 0.6, α=0.6, β=0.2) ≈ 6.0
-    @test quantile(v, 0.6, α=0.6, β=0.4) ≈ 6.0
-    @test quantile(v, 0.6, α=0.6, β=0.6) ≈ 6.0
-    @test quantile(v, 0.6, α=0.6, β=0.8) ≈ 6.0
-    @test quantile(v, 0.6, α=0.6, β=1.0) ≈ 6.0
-    @test quantile(v, 0.6, α=0.8, β=0.0) ≈ 6.0
-    @test quantile(v, 0.6, α=0.8, β=0.2) ≈ 6.0
-    @test quantile(v, 0.6, α=0.8, β=0.4) ≈ 6.0
-    @test quantile(v, 0.6, α=0.8, β=0.6) ≈ 6.0
-    @test quantile(v, 0.6, α=0.8, β=0.8) ≈ 6.0
-    @test quantile(v, 0.6, α=0.8, β=1.0) ≈ 6.0
-    @test quantile(v, 0.6, α=1.0, β=0.0) ≈ 6.0
-    @test quantile(v, 0.6, α=1.0, β=0.2) ≈ 6.0
-    @test quantile(v, 0.6, α=1.0, β=0.4) ≈ 6.0
-    @test quantile(v, 0.6, α=1.0, β=0.6) ≈ 6.0
-    @test quantile(v, 0.6, α=1.0, β=0.8) ≈ 6.0
     @test quantile(v, 0.6, α=1.0, β=1.0) ≈ 6.0
     @test quantile(v, 0.8, α=0.0, β=0.0) ≈ 15.4
     @test quantile(v, 0.8, α=0.0, β=0.2) ≈ 14.12

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -539,7 +539,7 @@ end
     #tests for quantile calculation with configurable alpha and beta parameters
     v = [2, 3, 4, 6, 9, 2, 6, 2, 21, 17]
 
-    # tests against SciPy quantile method
+    # tests against scipy.stats.mstats.mquantiles method
     @test quantile(v, 0.0, alpha=0.0, beta=0.0) ≈ 2.0
     @test quantile(v, 0.2, alpha=1.0, beta=1.0) ≈ 2.0
     @test quantile(v, 0.4, alpha=0.0, beta=0.0) ≈ 3.4

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -489,7 +489,7 @@ end
     @test quantile(100f0:-1f0:0.0, 0.0:0.1:1.0) ≈ 0f0:10f0:100f0
     @test quantile([Inf,Inf],0.5) == Inf
     @test quantile([-Inf,1],0.5) == -Inf
-    # here it is required to introduce an absolute tolerance because the calculated value is 0 in the method with parameters α and β
+    # here it is required to introduce an absolute tolerance because the calculated value is 0 in the method with parameters alpha and beta
     @test quantile([0,1],1e-18) ≈ 1e-18 atol=1e-18
     @test quantile([1, 2, 3, 4],[]) == []
     @test quantile([1, 2, 3, 4], (0.5,)) == (2.5,)
@@ -537,88 +537,88 @@ end
     @test quantile!(y, x, [0.1, 0.5, 0.9]) === y
     @test y ≈ [1.2, 2.0, 2.8]
 
-    #tests for quantile calculation with configurable α and β parameters
+    #tests for quantile calculation with configurable alpha and beta parameters
     v = [2, 3, 4, 6, 9, 2, 6, 2, 21, 17]
 
     # tests against SciPy quantile method
-    @test quantile(v, 0.0, α=0.0, β=0.0) ≈ 2.0
-    @test quantile(v, 0.2, α=1.0, β=1.0) ≈ 2.0
-    @test quantile(v, 0.4, α=0.0, β=0.0) ≈ 3.4
-    @test quantile(v, 0.4, α=0.0, β=0.2) ≈ 3.32
-    @test quantile(v, 0.4, α=0.0, β=0.4) ≈ 3.24
-    @test quantile(v, 0.4, α=0.0, β=0.6) ≈ 3.16
-    @test quantile(v, 0.4, α=0.0, β=0.8) ≈ 3.08
-    @test quantile(v, 0.4, α=0.0, β=1.0) ≈ 3.0
-    @test quantile(v, 0.4, α=0.2, β=0.0) ≈ 3.52
-    @test quantile(v, 0.4, α=0.2, β=0.2) ≈ 3.44
-    @test quantile(v, 0.4, α=0.2, β=0.4) ≈ 3.36
-    @test quantile(v, 0.4, α=0.2, β=0.6) ≈ 3.28
-    @test quantile(v, 0.4, α=0.2, β=0.8) ≈ 3.2
-    @test quantile(v, 0.4, α=0.2, β=1.0) ≈ 3.12
-    @test quantile(v, 0.4, α=0.4, β=0.0) ≈ 3.64
-    @test quantile(v, 0.4, α=0.4, β=0.2) ≈ 3.56
-    @test quantile(v, 0.4, α=0.4, β=0.4) ≈ 3.48
-    @test quantile(v, 0.4, α=0.4, β=0.6) ≈ 3.4
-    @test quantile(v, 0.4, α=0.4, β=0.8) ≈ 3.32
-    @test quantile(v, 0.4, α=0.4, β=1.0) ≈ 3.24
-    @test quantile(v, 0.4, α=0.6, β=0.0) ≈ 3.76
-    @test quantile(v, 0.4, α=0.6, β=0.2) ≈ 3.68
-    @test quantile(v, 0.4, α=0.6, β=0.4) ≈ 3.6
-    @test quantile(v, 0.4, α=0.6, β=0.6) ≈ 3.52
-    @test quantile(v, 0.4, α=0.6, β=0.8) ≈ 3.44
-    @test quantile(v, 0.4, α=0.6, β=1.0) ≈ 3.36
-    @test quantile(v, 0.4, α=0.8, β=0.0) ≈ 3.88
-    @test quantile(v, 0.4, α=0.8, β=0.2) ≈ 3.8
-    @test quantile(v, 0.4, α=0.8, β=0.4) ≈ 3.72
-    @test quantile(v, 0.4, α=0.8, β=0.6) ≈ 3.64
-    @test quantile(v, 0.4, α=0.8, β=0.8) ≈ 3.56
-    @test quantile(v, 0.4, α=0.8, β=1.0) ≈ 3.48
-    @test quantile(v, 0.4, α=1.0, β=0.0) ≈ 4.0
-    @test quantile(v, 0.4, α=1.0, β=0.2) ≈ 3.92
-    @test quantile(v, 0.4, α=1.0, β=0.4) ≈ 3.84
-    @test quantile(v, 0.4, α=1.0, β=0.6) ≈ 3.76
-    @test quantile(v, 0.4, α=1.0, β=0.8) ≈ 3.68
-    @test quantile(v, 0.4, α=1.0, β=1.0) ≈ 3.6
-    @test quantile(v, 0.6, α=0.0, β=0.0) ≈ 6.0
-    @test quantile(v, 0.6, α=1.0, β=1.0) ≈ 6.0
-    @test quantile(v, 0.8, α=0.0, β=0.0) ≈ 15.4
-    @test quantile(v, 0.8, α=0.0, β=0.2) ≈ 14.12
-    @test quantile(v, 0.8, α=0.0, β=0.4) ≈ 12.84
-    @test quantile(v, 0.8, α=0.0, β=0.6) ≈ 11.56
-    @test quantile(v, 0.8, α=0.0, β=0.8) ≈ 10.28
-    @test quantile(v, 0.8, α=0.0, β=1.0) ≈ 9.0
-    @test quantile(v, 0.8, α=0.2, β=0.0) ≈ 15.72
-    @test quantile(v, 0.8, α=0.2, β=0.2) ≈ 14.44
-    @test quantile(v, 0.8, α=0.2, β=0.4) ≈ 13.16
-    @test quantile(v, 0.8, α=0.2, β=0.6) ≈ 11.88
-    @test quantile(v, 0.8, α=0.2, β=0.8) ≈ 10.6
-    @test quantile(v, 0.8, α=0.2, β=1.0) ≈ 9.32
-    @test quantile(v, 0.8, α=0.4, β=0.0) ≈ 16.04
-    @test quantile(v, 0.8, α=0.4, β=0.2) ≈ 14.76
-    @test quantile(v, 0.8, α=0.4, β=0.4) ≈ 13.48
-    @test quantile(v, 0.8, α=0.4, β=0.6) ≈ 12.2
-    @test quantile(v, 0.8, α=0.4, β=0.8) ≈ 10.92
-    @test quantile(v, 0.8, α=0.4, β=1.0) ≈ 9.64
-    @test quantile(v, 0.8, α=0.6, β=0.0) ≈ 16.36
-    @test quantile(v, 0.8, α=0.6, β=0.2) ≈ 15.08
-    @test quantile(v, 0.8, α=0.6, β=0.4) ≈ 13.8
-    @test quantile(v, 0.8, α=0.6, β=0.6) ≈ 12.52
-    @test quantile(v, 0.8, α=0.6, β=0.8) ≈ 11.24
-    @test quantile(v, 0.8, α=0.6, β=1.0) ≈ 9.96
-    @test quantile(v, 0.8, α=0.8, β=0.0) ≈ 16.68
-    @test quantile(v, 0.8, α=0.8, β=0.2) ≈ 15.4
-    @test quantile(v, 0.8, α=0.8, β=0.4) ≈ 14.12
-    @test quantile(v, 0.8, α=0.8, β=0.6) ≈ 12.84
-    @test quantile(v, 0.8, α=0.8, β=0.8) ≈ 11.56
-    @test quantile(v, 0.8, α=0.8, β=1.0) ≈ 10.28
-    @test quantile(v, 0.8, α=1.0, β=0.0) ≈ 17.0
-    @test quantile(v, 0.8, α=1.0, β=0.2) ≈ 15.72
-    @test quantile(v, 0.8, α=1.0, β=0.4) ≈ 14.44
-    @test quantile(v, 0.8, α=1.0, β=0.6) ≈ 13.16
-    @test quantile(v, 0.8, α=1.0, β=0.8) ≈ 11.88
-    @test quantile(v, 0.8, α=1.0, β=1.0) ≈ 10.6
-    @test quantile(v, 1.0, α=0.0, β=0.0) ≈ 21.0
-    @test quantile(v, 1.0, α=1.0, β=1.0) ≈ 21.0
+    @test quantile(v, 0.0, alpha=0.0, beta=0.0) ≈ 2.0
+    @test quantile(v, 0.2, alpha=1.0, beta=1.0) ≈ 2.0
+    @test quantile(v, 0.4, alpha=0.0, beta=0.0) ≈ 3.4
+    @test quantile(v, 0.4, alpha=0.0, beta=0.2) ≈ 3.32
+    @test quantile(v, 0.4, alpha=0.0, beta=0.4) ≈ 3.24
+    @test quantile(v, 0.4, alpha=0.0, beta=0.6) ≈ 3.16
+    @test quantile(v, 0.4, alpha=0.0, beta=0.8) ≈ 3.08
+    @test quantile(v, 0.4, alpha=0.0, beta=1.0) ≈ 3.0
+    @test quantile(v, 0.4, alpha=0.2, beta=0.0) ≈ 3.52
+    @test quantile(v, 0.4, alpha=0.2, beta=0.2) ≈ 3.44
+    @test quantile(v, 0.4, alpha=0.2, beta=0.4) ≈ 3.36
+    @test quantile(v, 0.4, alpha=0.2, beta=0.6) ≈ 3.28
+    @test quantile(v, 0.4, alpha=0.2, beta=0.8) ≈ 3.2
+    @test quantile(v, 0.4, alpha=0.2, beta=1.0) ≈ 3.12
+    @test quantile(v, 0.4, alpha=0.4, beta=0.0) ≈ 3.64
+    @test quantile(v, 0.4, alpha=0.4, beta=0.2) ≈ 3.56
+    @test quantile(v, 0.4, alpha=0.4, beta=0.4) ≈ 3.48
+    @test quantile(v, 0.4, alpha=0.4, beta=0.6) ≈ 3.4
+    @test quantile(v, 0.4, alpha=0.4, beta=0.8) ≈ 3.32
+    @test quantile(v, 0.4, alpha=0.4, beta=1.0) ≈ 3.24
+    @test quantile(v, 0.4, alpha=0.6, beta=0.0) ≈ 3.76
+    @test quantile(v, 0.4, alpha=0.6, beta=0.2) ≈ 3.68
+    @test quantile(v, 0.4, alpha=0.6, beta=0.4) ≈ 3.6
+    @test quantile(v, 0.4, alpha=0.6, beta=0.6) ≈ 3.52
+    @test quantile(v, 0.4, alpha=0.6, beta=0.8) ≈ 3.44
+    @test quantile(v, 0.4, alpha=0.6, beta=1.0) ≈ 3.36
+    @test quantile(v, 0.4, alpha=0.8, beta=0.0) ≈ 3.88
+    @test quantile(v, 0.4, alpha=0.8, beta=0.2) ≈ 3.8
+    @test quantile(v, 0.4, alpha=0.8, beta=0.4) ≈ 3.72
+    @test quantile(v, 0.4, alpha=0.8, beta=0.6) ≈ 3.64
+    @test quantile(v, 0.4, alpha=0.8, beta=0.8) ≈ 3.56
+    @test quantile(v, 0.4, alpha=0.8, beta=1.0) ≈ 3.48
+    @test quantile(v, 0.4, alpha=1.0, beta=0.0) ≈ 4.0
+    @test quantile(v, 0.4, alpha=1.0, beta=0.2) ≈ 3.92
+    @test quantile(v, 0.4, alpha=1.0, beta=0.4) ≈ 3.84
+    @test quantile(v, 0.4, alpha=1.0, beta=0.6) ≈ 3.76
+    @test quantile(v, 0.4, alpha=1.0, beta=0.8) ≈ 3.68
+    @test quantile(v, 0.4, alpha=1.0, beta=1.0) ≈ 3.6
+    @test quantile(v, 0.6, alpha=0.0, beta=0.0) ≈ 6.0
+    @test quantile(v, 0.6, alpha=1.0, beta=1.0) ≈ 6.0
+    @test quantile(v, 0.8, alpha=0.0, beta=0.0) ≈ 15.4
+    @test quantile(v, 0.8, alpha=0.0, beta=0.2) ≈ 14.12
+    @test quantile(v, 0.8, alpha=0.0, beta=0.4) ≈ 12.84
+    @test quantile(v, 0.8, alpha=0.0, beta=0.6) ≈ 11.56
+    @test quantile(v, 0.8, alpha=0.0, beta=0.8) ≈ 10.28
+    @test quantile(v, 0.8, alpha=0.0, beta=1.0) ≈ 9.0
+    @test quantile(v, 0.8, alpha=0.2, beta=0.0) ≈ 15.72
+    @test quantile(v, 0.8, alpha=0.2, beta=0.2) ≈ 14.44
+    @test quantile(v, 0.8, alpha=0.2, beta=0.4) ≈ 13.16
+    @test quantile(v, 0.8, alpha=0.2, beta=0.6) ≈ 11.88
+    @test quantile(v, 0.8, alpha=0.2, beta=0.8) ≈ 10.6
+    @test quantile(v, 0.8, alpha=0.2, beta=1.0) ≈ 9.32
+    @test quantile(v, 0.8, alpha=0.4, beta=0.0) ≈ 16.04
+    @test quantile(v, 0.8, alpha=0.4, beta=0.2) ≈ 14.76
+    @test quantile(v, 0.8, alpha=0.4, beta=0.4) ≈ 13.48
+    @test quantile(v, 0.8, alpha=0.4, beta=0.6) ≈ 12.2
+    @test quantile(v, 0.8, alpha=0.4, beta=0.8) ≈ 10.92
+    @test quantile(v, 0.8, alpha=0.4, beta=1.0) ≈ 9.64
+    @test quantile(v, 0.8, alpha=0.6, beta=0.0) ≈ 16.36
+    @test quantile(v, 0.8, alpha=0.6, beta=0.2) ≈ 15.08
+    @test quantile(v, 0.8, alpha=0.6, beta=0.4) ≈ 13.8
+    @test quantile(v, 0.8, alpha=0.6, beta=0.6) ≈ 12.52
+    @test quantile(v, 0.8, alpha=0.6, beta=0.8) ≈ 11.24
+    @test quantile(v, 0.8, alpha=0.6, beta=1.0) ≈ 9.96
+    @test quantile(v, 0.8, alpha=0.8, beta=0.0) ≈ 16.68
+    @test quantile(v, 0.8, alpha=0.8, beta=0.2) ≈ 15.4
+    @test quantile(v, 0.8, alpha=0.8, beta=0.4) ≈ 14.12
+    @test quantile(v, 0.8, alpha=0.8, beta=0.6) ≈ 12.84
+    @test quantile(v, 0.8, alpha=0.8, beta=0.8) ≈ 11.56
+    @test quantile(v, 0.8, alpha=0.8, beta=1.0) ≈ 10.28
+    @test quantile(v, 0.8, alpha=1.0, beta=0.0) ≈ 17.0
+    @test quantile(v, 0.8, alpha=1.0, beta=0.2) ≈ 15.72
+    @test quantile(v, 0.8, alpha=1.0, beta=0.4) ≈ 14.44
+    @test quantile(v, 0.8, alpha=1.0, beta=0.6) ≈ 13.16
+    @test quantile(v, 0.8, alpha=1.0, beta=0.8) ≈ 11.88
+    @test quantile(v, 0.8, alpha=1.0, beta=1.0) ≈ 10.6
+    @test quantile(v, 1.0, alpha=0.0, beta=0.0) ≈ 21.0
+    @test quantile(v, 1.0, alpha=1.0, beta=1.0) ≈ 21.0
 end
 
 # StatsBase issue 164

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -534,6 +534,98 @@ end
     y = zeros(3)
     @test quantile!(y, x, [0.1, 0.5, 0.9]) === y
     @test y == [1.2, 2.0, 2.8]
+
+    #tests for quantile calculation with configurable α and β parameters
+    let v = [2, 3, 4, 6, 9, 2, 6, 2, 21, 17]
+        # consistency to standard quantile method
+        @test quantile(v, 0.7) ≈ quantile(v, 0.7, 1, 1)
+        @test quantile(v, 0.99) ≈ quantile(v, 0.99, 1, 1)
+
+        # tests against SciPy quantile method
+        @test quantile(v, 0.0, 0.0, 0.0) ≈ 2.0
+        @test quantile(v, 0.2, 1.0, 1.0) ≈ 2.0
+        @test quantile(v, 0.4, 0.0, 0.0) ≈ 3.4000000000000004
+        @test quantile(v, 0.4, 0.0, 0.2) ≈ 3.3200000000000003
+        @test quantile(v, 0.4, 0.0, 0.4) ≈ 3.24
+        @test quantile(v, 0.4, 0.0, 0.6) ≈ 3.16
+        @test quantile(v, 0.4, 0.0, 0.8) ≈ 3.08
+        @test quantile(v, 0.4, 0.0, 1.0) ≈ 3.0
+        @test quantile(v, 0.4, 0.2, 0.0) ≈ 3.5199999999999996
+        @test quantile(v, 0.4, 0.2, 0.2) ≈ 3.4400000000000004
+        @test quantile(v, 0.4, 0.2, 0.4) ≈ 3.3600000000000003
+        @test quantile(v, 0.4, 0.2, 0.6) ≈ 3.2800000000000002
+        @test quantile(v, 0.4, 0.2, 0.8) ≈ 3.2
+        @test quantile(v, 0.4, 0.2, 1.0) ≈ 3.12
+        @test quantile(v, 0.4, 0.4, 0.0) ≈ 3.6399999999999997
+        @test quantile(v, 0.4, 0.4, 0.2) ≈ 3.5600000000000005
+        @test quantile(v, 0.4, 0.4, 0.4) ≈ 3.4800000000000004
+        @test quantile(v, 0.4, 0.4, 0.6) ≈ 3.4000000000000004
+        @test quantile(v, 0.4, 0.4, 0.8) ≈ 3.3200000000000003
+        @test quantile(v, 0.4, 0.4, 1.0) ≈ 3.24
+        @test quantile(v, 0.4, 0.6, 0.0) ≈ 3.76
+        @test quantile(v, 0.4, 0.6, 0.2) ≈ 3.6799999999999997
+        @test quantile(v, 0.4, 0.6, 0.4) ≈ 3.5999999999999996
+        @test quantile(v, 0.4, 0.6, 0.6) ≈ 3.5199999999999996
+        @test quantile(v, 0.4, 0.6, 0.8) ≈ 3.4399999999999995
+        @test quantile(v, 0.4, 0.6, 1.0) ≈ 3.3600000000000003
+        @test quantile(v, 0.4, 0.8, 0.0) ≈ 3.88
+        @test quantile(v, 0.4, 0.8, 0.2) ≈ 3.8
+        @test quantile(v, 0.4, 0.8, 0.4) ≈ 3.7199999999999998
+        @test quantile(v, 0.4, 0.8, 0.6) ≈ 3.6399999999999997
+        @test quantile(v, 0.4, 0.8, 0.8) ≈ 3.5600000000000005
+        @test quantile(v, 0.4, 0.8, 1.0) ≈ 3.4800000000000004
+        @test quantile(v, 0.4, 1.0, 0.0) ≈ 4.0
+        @test quantile(v, 0.4, 1.0, 0.2) ≈ 3.92
+        @test quantile(v, 0.4, 1.0, 0.4) ≈ 3.84
+        @test quantile(v, 0.4, 1.0, 0.6) ≈ 3.76
+        @test quantile(v, 0.4, 1.0, 0.8) ≈ 3.6799999999999997
+        @test quantile(v, 0.4, 1.0, 1.0) ≈ 3.5999999999999996
+        @test quantile(v, 0.6, 0.0, 0.0) ≈ 6.0
+        @test quantile(v, 0.6, 1.0, 1.0) ≈ 6.0
+        @test quantile(v, 0.8, 0.0, 0.0) ≈ 15.400000000000006
+        @test quantile(v, 0.8, 0.0, 0.2) ≈ 14.120000000000005
+        @test quantile(v, 0.8, 0.0, 0.4) ≈ 12.840000000000003
+        @test quantile(v, 0.8, 0.0, 0.6) ≈ 11.560000000000002
+        @test quantile(v, 0.8, 0.0, 0.8) ≈ 10.280000000000001
+        @test quantile(v, 0.8, 0.0, 1.0) ≈ 9.0
+        @test quantile(v, 0.8, 0.2, 0.0) ≈ 15.719999999999999
+        @test quantile(v, 0.8, 0.2, 0.2) ≈ 14.439999999999998
+        @test quantile(v, 0.8, 0.2, 0.4) ≈ 13.159999999999997
+        @test quantile(v, 0.8, 0.2, 0.6) ≈ 11.879999999999995
+        @test quantile(v, 0.8, 0.2, 0.8) ≈ 10.599999999999994
+        @test quantile(v, 0.8, 0.2, 1.0) ≈ 9.319999999999993
+        @test quantile(v, 0.8, 0.4, 0.0) ≈ 16.040000000000006
+        @test quantile(v, 0.8, 0.4, 0.2) ≈ 14.760000000000005
+        @test quantile(v, 0.8, 0.4, 0.4) ≈ 13.480000000000004
+        @test quantile(v, 0.8, 0.4, 0.6) ≈ 12.200000000000003
+        @test quantile(v, 0.8, 0.4, 0.8) ≈ 10.920000000000002
+        @test quantile(v, 0.8, 0.4, 1.0) ≈ 9.64
+        @test quantile(v, 0.8, 0.6, 0.0) ≈ 16.36
+        @test quantile(v, 0.8, 0.6, 0.2) ≈ 15.079999999999998
+        @test quantile(v, 0.8, 0.6, 0.4) ≈ 13.799999999999997
+        @test quantile(v, 0.8, 0.6, 0.6) ≈ 12.519999999999996
+        @test quantile(v, 0.8, 0.6, 0.8) ≈ 11.239999999999995
+        @test quantile(v, 0.8, 0.6, 1.0) ≈ 9.959999999999994
+        @test quantile(v, 0.8, 0.8, 0.0) ≈ 16.680000000000007
+        @test quantile(v, 0.8, 0.8, 0.2) ≈ 15.400000000000006
+        @test quantile(v, 0.8, 0.8, 0.4) ≈ 14.120000000000005
+        @test quantile(v, 0.8, 0.8, 0.6) ≈ 12.840000000000003
+        @test quantile(v, 0.8, 0.8, 0.8) ≈ 11.560000000000002
+        @test quantile(v, 0.8, 0.8, 1.0) ≈ 10.280000000000001
+        @test quantile(v, 0.8, 1.0, 0.0) ≈ 17.0
+        @test quantile(v, 0.8, 1.0, 0.2) ≈ 15.719999999999999
+        @test quantile(v, 0.8, 1.0, 0.4) ≈ 14.439999999999998
+        @test quantile(v, 0.8, 1.0, 0.6) ≈ 13.159999999999997
+        @test quantile(v, 0.8, 1.0, 0.8) ≈ 11.879999999999995
+        @test quantile(v, 0.8, 1.0, 1.0) ≈ 10.599999999999994
+        @test quantile(v, 1.0, 0.0, 0.0) ≈ 21.0
+        @test quantile(v, 1.0, 1.0, 1.0) ≈ 21.0
+
+
+    end
+
+
+
 end
 
 # StatsBase issue 164

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-using Statistics, Test, Random, LinearAlgebra, SparseArrays
+using Statistics,
+using Test, Random, LinearAlgebra, SparseArrays
 using Test: guardseed
 
 Random.seed!(123)
@@ -480,29 +481,30 @@ end
 end
 
 @testset "quantile" begin
-    @test quantile([1,2,3,4],0.5) == 2.5
-    @test quantile([1,2,3,4],[0.5]) == [2.5]
-    @test quantile([1., 3],[.25,.5,.75])[2] == median([1., 3])
-    @test quantile(100.0:-1.0:0.0, 0.0:0.1:1.0) == 0.0:10.0:100.0
-    @test quantile(0.0:100.0, 0.0:0.1:1.0, sorted=true) == 0.0:10.0:100.0
-    @test quantile(100f0:-1f0:0.0, 0.0:0.1:1.0) == 0f0:10f0:100f0
+    @test quantile([1,2,3,4],0.5) ≈ 2.5
+    @test quantile([1,2,3,4],[0.5]) ≈ [2.5]
+    @test quantile([1., 3],[.25,.5,.75])[2] ≈ median([1., 3])
+    @test quantile(100.0:-1.0:0.0, 0.0:0.1:1.0) ≈ 0.0:10.0:100.0
+    @test quantile(0.0:100.0, 0.0:0.1:1.0, sorted=true) ≈ 0.0:10.0:100.0
+    @test quantile(100f0:-1f0:0.0, 0.0:0.1:1.0) ≈ 0f0:10f0:100f0
     @test quantile([Inf,Inf],0.5) == Inf
     @test quantile([-Inf,1],0.5) == -Inf
-    @test quantile([0,1],1e-18) == 1e-18
+    # here it is required to introduce an absolute tolerance because the calculated value is 0 in the method with parameters α and β
+    @test quantile([0,1],1e-18) ≈ 1e-18 atol=1e-18
     @test quantile([1, 2, 3, 4],[]) == []
     @test quantile([1, 2, 3, 4], (0.5,)) == (2.5,)
     @test quantile([4, 9, 1, 5, 7, 8, 2, 3, 5, 17, 11],
                    (0.1, 0.2, 0.4, 0.9)) == (2.0, 3.0, 5.0, 11.0)
     @test quantile(Union{Int, Missing}[4, 9, 1, 5, 7, 8, 2, 3, 5, 17, 11],
-                   [0.1, 0.2, 0.4, 0.9]) == [2.0, 3.0, 5.0, 11.0]
+                   [0.1, 0.2, 0.4, 0.9]) ≈ [2.0, 3.0, 5.0, 11.0]
     @test quantile(Any[4, 9, 1, 5, 7, 8, 2, 3, 5, 17, 11],
-                   [0.1, 0.2, 0.4, 0.9]) == [2.0, 3.0, 5.0, 11.0]
+                   [0.1, 0.2, 0.4, 0.9]) ≈ [2.0, 3.0, 5.0, 11.0]
     @test quantile([4, 9, 1, 5, 7, 8, 2, 3, 5, 17, 11],
-                   Any[0.1, 0.2, 0.4, 0.9]) == [2.0, 3.0, 5.0, 11.0]
+                   Any[0.1, 0.2, 0.4, 0.9]) ≈ [2.0, 3.0, 5.0, 11.0]
     @test quantile([4, 9, 1, 5, 7, 8, 2, 3, 5, 17, 11],
                    Any[0.1, 0.2, 0.4, 0.9]) isa Vector{Float64}
     @test quantile(Any[4, 9, 1, 5, 7, 8, 2, 3, 5, 17, 11],
-                   Any[0.1, 0.2, 0.4, 0.9]) == [2, 3, 5, 11]
+                   Any[0.1, 0.2, 0.4, 0.9]) ≈ [2, 3, 5, 11]
     @test quantile(Any[4, 9, 1, 5, 7, 8, 2, 3, 5, 17, 11],
                    Any[0.1, 0.2, 0.4, 0.9]) isa Vector{Float64}
     @test quantile([1, 2, 3, 4], ()) == ()
@@ -533,7 +535,7 @@ end
     x = [3; 2; 1]
     y = zeros(3)
     @test quantile!(y, x, [0.1, 0.5, 0.9]) === y
-    @test y == [1.2, 2.0, 2.8]
+    @test y ≈ [1.2, 2.0, 2.8]
 
     #tests for quantile calculation with configurable α and β parameters
     v = [2, 3, 4, 6, 9, 2, 6, 2, 21, 17]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -511,12 +511,12 @@ end
     @test isempty(quantile([1, 2, 3, 4], Float64[]))
     @test quantile([1, 2, 3, 4], Float64[]) isa Vector{Float64}
     @test quantile([1, 2, 3, 4], []) isa Vector{Any}
-    @test quantile([1, 2, 3, 4], [0, 1]) isa Vector{Int}
+    @test quantile([1, 2, 3, 4], [0, 1], alpha=1) isa Vector{Int}
 
     @test quantile(Any[1, 2, 3], 0.5) isa Float64
     @test quantile(Any[1, big(2), 3], 0.5) isa BigFloat
-    @test quantile(Any[1, 2, 3], Float16(0.5)) isa Float16
-    @test quantile(Any[1, Float16(2), 3], Float16(0.5)) isa Float16
+    @test quantile(Any[1, 2, 3], Float16(0.5), alpha=1) isa Float16 # default type of alpha is Float
+    @test quantile(Any[1, Float16(2), 3], Float16(0.5), alpha=1) isa Float16
     @test quantile(Any[1, big(2), 3], Float16(0.5)) isa BigFloat
 
     @test_throws ArgumentError quantile([1, missing], 0.5)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -543,80 +543,114 @@ end
     # tests against SciPy quantile method
     @test quantile(v, 0.0, α=0.0, β=0.0) ≈ 2.0
     @test quantile(v, 0.2, α=1.0, β=1.0) ≈ 2.0
-    @test quantile(v, 0.4, α=0.0, β=0.0) ≈ 3.4000000000000004
-    @test quantile(v, 0.4, α=0.0, β=0.2) ≈ 3.3200000000000003
+    @test quantile(v, 0.4, α=0.0, β=0.0) ≈ 3.4
+    @test quantile(v, 0.4, α=0.0, β=0.2) ≈ 3.32
     @test quantile(v, 0.4, α=0.0, β=0.4) ≈ 3.24
     @test quantile(v, 0.4, α=0.0, β=0.6) ≈ 3.16
     @test quantile(v, 0.4, α=0.0, β=0.8) ≈ 3.08
     @test quantile(v, 0.4, α=0.0, β=1.0) ≈ 3.0
-    @test quantile(v, 0.4, α=0.2, β=0.0) ≈ 3.5199999999999996
-    @test quantile(v, 0.4, α=0.2, β=0.2) ≈ 3.4400000000000004
-    @test quantile(v, 0.4, α=0.2, β=0.4) ≈ 3.3600000000000003
-    @test quantile(v, 0.4, α=0.2, β=0.6) ≈ 3.2800000000000002
+    @test quantile(v, 0.4, α=0.2, β=0.0) ≈ 3.52
+    @test quantile(v, 0.4, α=0.2, β=0.2) ≈ 3.44
+    @test quantile(v, 0.4, α=0.2, β=0.4) ≈ 3.36
+    @test quantile(v, 0.4, α=0.2, β=0.6) ≈ 3.28
     @test quantile(v, 0.4, α=0.2, β=0.8) ≈ 3.2
     @test quantile(v, 0.4, α=0.2, β=1.0) ≈ 3.12
-    @test quantile(v, 0.4, α=0.4, β=0.0) ≈ 3.6399999999999997
-    @test quantile(v, 0.4, α=0.4, β=0.2) ≈ 3.5600000000000005
-    @test quantile(v, 0.4, α=0.4, β=0.4) ≈ 3.4800000000000004
-    @test quantile(v, 0.4, α=0.4, β=0.6) ≈ 3.4000000000000004
-    @test quantile(v, 0.4, α=0.4, β=0.8) ≈ 3.3200000000000003
+    @test quantile(v, 0.4, α=0.4, β=0.0) ≈ 3.64
+    @test quantile(v, 0.4, α=0.4, β=0.2) ≈ 3.56
+    @test quantile(v, 0.4, α=0.4, β=0.4) ≈ 3.48
+    @test quantile(v, 0.4, α=0.4, β=0.6) ≈ 3.4
+    @test quantile(v, 0.4, α=0.4, β=0.8) ≈ 3.32
     @test quantile(v, 0.4, α=0.4, β=1.0) ≈ 3.24
     @test quantile(v, 0.4, α=0.6, β=0.0) ≈ 3.76
-    @test quantile(v, 0.4, α=0.6, β=0.2) ≈ 3.6799999999999997
-    @test quantile(v, 0.4, α=0.6, β=0.4) ≈ 3.5999999999999996
-    @test quantile(v, 0.4, α=0.6, β=0.6) ≈ 3.5199999999999996
-    @test quantile(v, 0.4, α=0.6, β=0.8) ≈ 3.4399999999999995
-    @test quantile(v, 0.4, α=0.6, β=1.0) ≈ 3.3600000000000003
+    @test quantile(v, 0.4, α=0.6, β=0.2) ≈ 3.68
+    @test quantile(v, 0.4, α=0.6, β=0.4) ≈ 3.6
+    @test quantile(v, 0.4, α=0.6, β=0.6) ≈ 3.52
+    @test quantile(v, 0.4, α=0.6, β=0.8) ≈ 3.44
+    @test quantile(v, 0.4, α=0.6, β=1.0) ≈ 3.36
     @test quantile(v, 0.4, α=0.8, β=0.0) ≈ 3.88
     @test quantile(v, 0.4, α=0.8, β=0.2) ≈ 3.8
-    @test quantile(v, 0.4, α=0.8, β=0.4) ≈ 3.7199999999999998
-    @test quantile(v, 0.4, α=0.8, β=0.6) ≈ 3.6399999999999997
-    @test quantile(v, 0.4, α=0.8, β=0.8) ≈ 3.5600000000000005
-    @test quantile(v, 0.4, α=0.8, β=1.0) ≈ 3.4800000000000004
+    @test quantile(v, 0.4, α=0.8, β=0.4) ≈ 3.72
+    @test quantile(v, 0.4, α=0.8, β=0.6) ≈ 3.64
+    @test quantile(v, 0.4, α=0.8, β=0.8) ≈ 3.56
+    @test quantile(v, 0.4, α=0.8, β=1.0) ≈ 3.48
     @test quantile(v, 0.4, α=1.0, β=0.0) ≈ 4.0
     @test quantile(v, 0.4, α=1.0, β=0.2) ≈ 3.92
     @test quantile(v, 0.4, α=1.0, β=0.4) ≈ 3.84
     @test quantile(v, 0.4, α=1.0, β=0.6) ≈ 3.76
-    @test quantile(v, 0.4, α=1.0, β=0.8) ≈ 3.6799999999999997
-    @test quantile(v, 0.4, α=1.0, β=1.0) ≈ 3.5999999999999996
+    @test quantile(v, 0.4, α=1.0, β=0.8) ≈ 3.68
+    @test quantile(v, 0.4, α=1.0, β=1.0) ≈ 3.6
     @test quantile(v, 0.6, α=0.0, β=0.0) ≈ 6.0
+    @test quantile(v, 0.6, α=0.0, β=0.2) ≈ 6.0
+    @test quantile(v, 0.6, α=0.0, β=0.4) ≈ 6.0
+    @test quantile(v, 0.6, α=0.0, β=0.6) ≈ 6.0
+    @test quantile(v, 0.6, α=0.0, β=0.8) ≈ 6.0
+    @test quantile(v, 0.6, α=0.0, β=1.0) ≈ 6.0
+    @test quantile(v, 0.6, α=0.2, β=0.0) ≈ 6.0
+    @test quantile(v, 0.6, α=0.2, β=0.2) ≈ 6.0
+    @test quantile(v, 0.6, α=0.2, β=0.4) ≈ 6.0
+    @test quantile(v, 0.6, α=0.2, β=0.6) ≈ 6.0
+    @test quantile(v, 0.6, α=0.2, β=0.8) ≈ 6.0
+    @test quantile(v, 0.6, α=0.2, β=1.0) ≈ 6.0
+    @test quantile(v, 0.6, α=0.4, β=0.0) ≈ 6.0
+    @test quantile(v, 0.6, α=0.4, β=0.2) ≈ 6.0
+    @test quantile(v, 0.6, α=0.4, β=0.4) ≈ 6.0
+    @test quantile(v, 0.6, α=0.4, β=0.6) ≈ 6.0
+    @test quantile(v, 0.6, α=0.4, β=0.8) ≈ 6.0
+    @test quantile(v, 0.6, α=0.4, β=1.0) ≈ 6.0
+    @test quantile(v, 0.6, α=0.6, β=0.0) ≈ 6.0
+    @test quantile(v, 0.6, α=0.6, β=0.2) ≈ 6.0
+    @test quantile(v, 0.6, α=0.6, β=0.4) ≈ 6.0
+    @test quantile(v, 0.6, α=0.6, β=0.6) ≈ 6.0
+    @test quantile(v, 0.6, α=0.6, β=0.8) ≈ 6.0
+    @test quantile(v, 0.6, α=0.6, β=1.0) ≈ 6.0
+    @test quantile(v, 0.6, α=0.8, β=0.0) ≈ 6.0
+    @test quantile(v, 0.6, α=0.8, β=0.2) ≈ 6.0
+    @test quantile(v, 0.6, α=0.8, β=0.4) ≈ 6.0
+    @test quantile(v, 0.6, α=0.8, β=0.6) ≈ 6.0
+    @test quantile(v, 0.6, α=0.8, β=0.8) ≈ 6.0
+    @test quantile(v, 0.6, α=0.8, β=1.0) ≈ 6.0
+    @test quantile(v, 0.6, α=1.0, β=0.0) ≈ 6.0
+    @test quantile(v, 0.6, α=1.0, β=0.2) ≈ 6.0
+    @test quantile(v, 0.6, α=1.0, β=0.4) ≈ 6.0
+    @test quantile(v, 0.6, α=1.0, β=0.6) ≈ 6.0
+    @test quantile(v, 0.6, α=1.0, β=0.8) ≈ 6.0
     @test quantile(v, 0.6, α=1.0, β=1.0) ≈ 6.0
-    @test quantile(v, 0.8, α=0.0, β=0.0) ≈ 15.400000000000006
-    @test quantile(v, 0.8, α=0.0, β=0.2) ≈ 14.120000000000005
-    @test quantile(v, 0.8, α=0.0, β=0.4) ≈ 12.840000000000003
-    @test quantile(v, 0.8, α=0.0, β=0.6) ≈ 11.560000000000002
-    @test quantile(v, 0.8, α=0.0, β=0.8) ≈ 10.280000000000001
+    @test quantile(v, 0.8, α=0.0, β=0.0) ≈ 15.4
+    @test quantile(v, 0.8, α=0.0, β=0.2) ≈ 14.12
+    @test quantile(v, 0.8, α=0.0, β=0.4) ≈ 12.84
+    @test quantile(v, 0.8, α=0.0, β=0.6) ≈ 11.56
+    @test quantile(v, 0.8, α=0.0, β=0.8) ≈ 10.28
     @test quantile(v, 0.8, α=0.0, β=1.0) ≈ 9.0
-    @test quantile(v, 0.8, α=0.2, β=0.0) ≈ 15.719999999999999
-    @test quantile(v, 0.8, α=0.2, β=0.2) ≈ 14.439999999999998
-    @test quantile(v, 0.8, α=0.2, β=0.4) ≈ 13.159999999999997
-    @test quantile(v, 0.8, α=0.2, β=0.6) ≈ 11.879999999999995
-    @test quantile(v, 0.8, α=0.2, β=0.8) ≈ 10.599999999999994
-    @test quantile(v, 0.8, α=0.2, β=1.0) ≈ 9.319999999999993
-    @test quantile(v, 0.8, α=0.4, β=0.0) ≈ 16.040000000000006
-    @test quantile(v, 0.8, α=0.4, β=0.2) ≈ 14.760000000000005
-    @test quantile(v, 0.8, α=0.4, β=0.4) ≈ 13.480000000000004
-    @test quantile(v, 0.8, α=0.4, β=0.6) ≈ 12.200000000000003
-    @test quantile(v, 0.8, α=0.4, β=0.8) ≈ 10.920000000000002
+    @test quantile(v, 0.8, α=0.2, β=0.0) ≈ 15.72
+    @test quantile(v, 0.8, α=0.2, β=0.2) ≈ 14.44
+    @test quantile(v, 0.8, α=0.2, β=0.4) ≈ 13.16
+    @test quantile(v, 0.8, α=0.2, β=0.6) ≈ 11.88
+    @test quantile(v, 0.8, α=0.2, β=0.8) ≈ 10.6
+    @test quantile(v, 0.8, α=0.2, β=1.0) ≈ 9.32
+    @test quantile(v, 0.8, α=0.4, β=0.0) ≈ 16.04
+    @test quantile(v, 0.8, α=0.4, β=0.2) ≈ 14.76
+    @test quantile(v, 0.8, α=0.4, β=0.4) ≈ 13.48
+    @test quantile(v, 0.8, α=0.4, β=0.6) ≈ 12.2
+    @test quantile(v, 0.8, α=0.4, β=0.8) ≈ 10.92
     @test quantile(v, 0.8, α=0.4, β=1.0) ≈ 9.64
     @test quantile(v, 0.8, α=0.6, β=0.0) ≈ 16.36
-    @test quantile(v, 0.8, α=0.6, β=0.2) ≈ 15.079999999999998
-    @test quantile(v, 0.8, α=0.6, β=0.4) ≈ 13.799999999999997
-    @test quantile(v, 0.8, α=0.6, β=0.6) ≈ 12.519999999999996
-    @test quantile(v, 0.8, α=0.6, β=0.8) ≈ 11.239999999999995
-    @test quantile(v, 0.8, α=0.6, β=1.0) ≈ 9.959999999999994
-    @test quantile(v, 0.8, α=0.8, β=0.0) ≈ 16.680000000000007
-    @test quantile(v, 0.8, α=0.8, β=0.2) ≈ 15.400000000000006
-    @test quantile(v, 0.8, α=0.8, β=0.4) ≈ 14.120000000000005
-    @test quantile(v, 0.8, α=0.8, β=0.6) ≈ 12.840000000000003
-    @test quantile(v, 0.8, α=0.8, β=0.8) ≈ 11.560000000000002
-    @test quantile(v, 0.8, α=0.8, β=1.0) ≈ 10.280000000000001
+    @test quantile(v, 0.8, α=0.6, β=0.2) ≈ 15.08
+    @test quantile(v, 0.8, α=0.6, β=0.4) ≈ 13.8
+    @test quantile(v, 0.8, α=0.6, β=0.6) ≈ 12.52
+    @test quantile(v, 0.8, α=0.6, β=0.8) ≈ 11.24
+    @test quantile(v, 0.8, α=0.6, β=1.0) ≈ 9.96
+    @test quantile(v, 0.8, α=0.8, β=0.0) ≈ 16.68
+    @test quantile(v, 0.8, α=0.8, β=0.2) ≈ 15.4
+    @test quantile(v, 0.8, α=0.8, β=0.4) ≈ 14.12
+    @test quantile(v, 0.8, α=0.8, β=0.6) ≈ 12.84
+    @test quantile(v, 0.8, α=0.8, β=0.8) ≈ 11.56
+    @test quantile(v, 0.8, α=0.8, β=1.0) ≈ 10.28
     @test quantile(v, 0.8, α=1.0, β=0.0) ≈ 17.0
-    @test quantile(v, 0.8, α=1.0, β=0.2) ≈ 15.719999999999999
-    @test quantile(v, 0.8, α=1.0, β=0.4) ≈ 14.439999999999998
-    @test quantile(v, 0.8, α=1.0, β=0.6) ≈ 13.159999999999997
-    @test quantile(v, 0.8, α=1.0, β=0.8) ≈ 11.879999999999995
-    @test quantile(v, 0.8, α=1.0, β=1.0) ≈ 10.599999999999994
+    @test quantile(v, 0.8, α=1.0, β=0.2) ≈ 15.72
+    @test quantile(v, 0.8, α=1.0, β=0.4) ≈ 14.44
+    @test quantile(v, 0.8, α=1.0, β=0.6) ≈ 13.16
+    @test quantile(v, 0.8, α=1.0, β=0.8) ≈ 11.88
+    @test quantile(v, 0.8, α=1.0, β=1.0) ≈ 10.6
     @test quantile(v, 1.0, α=0.0, β=0.0) ≈ 21.0
     @test quantile(v, 1.0, α=1.0, β=1.0) ≈ 21.0
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -514,7 +514,7 @@ end
 
     @test quantile(Any[1, 2, 3], 0.5) isa Float64
     @test quantile(Any[1, big(2), 3], 0.5) isa BigFloat
-    @test quantile(Any[1, 2, 3], Float16(0.5)) isa Float16 # default type of alpha is Float
+    @test quantile(Any[1, 2, 3], Float16(0.5)) isa Float16
     @test quantile(Any[1, Float16(2), 3], Float16(0.5)) isa Float16
     @test quantile(Any[1, big(2), 3], Float16(0.5)) isa BigFloat
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -712,8 +712,8 @@ end
     @test var(x) === 16.25
     @test var(y) === 65//4
     @test std(x) === sqrt(16.25)
-    @test quantile(x, 0.5)  === 3.0
-    @test quantile(x, 1//2) === 3//1
+    @test quantile(x, 0.5, alpha=1)  === 3.0
+    @test quantile(x, 1//2, alpha=1) === 3//1
 end
 
 @testset "Promotion in covzm. Issue #8080" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -510,12 +510,12 @@ end
     @test isempty(quantile([1, 2, 3, 4], Float64[]))
     @test quantile([1, 2, 3, 4], Float64[]) isa Vector{Float64}
     @test quantile([1, 2, 3, 4], []) isa Vector{Any}
-    @test quantile([1, 2, 3, 4], [0, 1], alpha=1) isa Vector{Int}
+    @test quantile([1, 2, 3, 4], [0, 1]) isa Vector{Int}
 
     @test quantile(Any[1, 2, 3], 0.5) isa Float64
     @test quantile(Any[1, big(2), 3], 0.5) isa BigFloat
-    @test quantile(Any[1, 2, 3], Float16(0.5), alpha=1) isa Float16 # default type of alpha is Float
-    @test quantile(Any[1, Float16(2), 3], Float16(0.5), alpha=1) isa Float16
+    @test quantile(Any[1, 2, 3], Float16(0.5)) isa Float16 # default type of alpha is Float
+    @test quantile(Any[1, Float16(2), 3], Float16(0.5)) isa Float16
     @test quantile(Any[1, big(2), 3], Float16(0.5)) isa BigFloat
 
     @test_throws ArgumentError quantile([1, missing], 0.5)
@@ -712,8 +712,8 @@ end
     @test var(x) === 16.25
     @test var(y) === 65//4
     @test std(x) === sqrt(16.25)
-    @test quantile(x, 0.5, alpha=1)  === 3.0
-    @test quantile(x, 1//2, alpha=1) === 3//1
+    @test quantile(x, 0.5)  === 3.0
+    @test quantile(x, 1//2) === 3//1
 end
 
 @testset "Promotion in covzm. Issue #8080" begin


### PR DESCRIPTION
Currently, the quantile estimator definition 7 of
Hyndman, R.J and Fan, Y. (1996) "Sample Quantiles in Statistical Packages",
The American Statistician, Vol. 50, No. 4, pp. 361-365
is used for quantile calculation.

I suggest to add a generic quantile estimator method with alpha and beta as free parameters, so that the definitions 4-9 in the paper above can be used.

The following code gives the correct results (tested against SciPy), but has slightly worse performance than the current implementation.
However, thanks to dispatch, the existing implementation is used if alpha and beta are not given, therefore there should be no performance impact to existing code.