### PR TITLE
Solve the overflow in mean() on integers by promoting accumulator

### DIFF
--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -163,7 +163,7 @@ julia> mean(A, dims=2)
  1.5
  3.5
 ```
-""" 
+"""
 mean(A::AbstractArray; dims=:) = _mean(A, dims)
 
 _mean(A::AbstractArray{T}, region) where {T} = mean!(Base.reducedim_init(t -> t/2, +, A, region), A)

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -173,7 +173,12 @@ function _mean(f, A::AbstractArray, dims=:)
         n = mapreduce(i -> size(A, i), *, unique(dims); init=1)
     end
     x1 = f(first(A)) / 1
-    return sum(x -> _mean_promote(x1, f(x)), A, dims=dims) / n
+    result = sum(x -> _mean_promote(x1, f(x)), A, dims=dims)
+    if dims === (:)
+        result /= n
+    else
+        result ./= n
+    end
 end
 
 function mean(r::AbstractRange{<:Real})

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -167,7 +167,16 @@ julia> mean(A, dims=2)
 mean(A::AbstractArray; dims=:) = _mean(A, dims)
 
 _mean(A::AbstractArray{T}, region) where {T} = mean!(Base.reducedim_init(t -> t/2, +, A, region), A)
-_mean(A::AbstractArray, ::Colon) = sum(A) / length(A)
+_prom(x::Missing, y) = (x,y)
+_prom(x, y::Missing) = (x,y)
+_prom(x::Missing, y::Missing) = (x,y)
+_prom(x,y)=promote(x,y)
+function _mean(A::AbstractArray, ::Colon)
+    isempty(A) && return one(eltype(A))*NaN
+    n = length(A)
+    x1 = first(A) / n
+    return sum(x -> first(_prom(x,x1)), A) / n
+end
 
 function mean(r::AbstractRange{<:Real})
     isempty(r) && return oftype((first(r) + last(r)) / 2, NaN)

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -167,12 +167,12 @@ _mean_promote(x::T, y::S) where {T,S} = convert(promote_type(T, S), y)
 
 function _mean(f, A::AbstractArray, dims=:)
     isempty(A) && return sum(f, A, dims=dims)/0
-    if dims == Colon()
+    if dims === (:)
         n = length(A)
     else
         n = mapreduce(i -> size(A, i), *, unique(dims); init=1)
     end
-    x1 = f(first(A)) / n
+    x1 = f(first(A)) / 1
     return sum(x -> _mean_promote(x1, f(x)), A, dims=dims) / n
 end
 

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -161,9 +161,7 @@ julia> mean(A, dims=2)
  3.5
 ```
 """
-#mean(A::AbstractArray; dims=:) = _mean(identity, A, dims)
-mean(A::AbstractArray; dims=:) = _mean(A, dims)
-_mean(A::AbstractArray{T}, region) where {T} = mean!(Base.reducedim_init(t -> t/2, +, A, region), A)
+mean(A::AbstractArray; dims=:) = _mean(identity, A, dims)
 
 _mean(A::AbstractArray, ::Colon) = _mean(identity, A)
 
@@ -172,7 +170,7 @@ _mean_promote(x::T, y::S) where {T,S} = convert(promote_type(T, S), y)
 function _mean(f, A::AbstractArray, dims=:)
     isempty(A) && return sum(f, A, dims=dims)/0
     if dims == Colon()
-        n =length(A)
+        n = length(A)
     else
         n = mapreduce(i -> size(A, i), *, unique(dims); init=1)
     end

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -175,9 +175,9 @@ function _mean(f, A::AbstractArray, dims=:)
     x1 = f(first(A)) / 1
     result = sum(x -> _mean_promote(x1, f(x)), A, dims=dims)
     if dims === (:)
-        result /= n
+        return result / n
     else
-        result ./= n
+        return result ./= n
     end
 end
 

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -163,19 +163,19 @@ julia> mean(A, dims=2)
  1.5
  3.5
 ```
-"""
+""" 
 mean(A::AbstractArray; dims=:) = _mean(A, dims)
 
 _mean(A::AbstractArray{T}, region) where {T} = mean!(Base.reducedim_init(t -> t/2, +, A, region), A)
-_prom(x::Missing, y) = (x,y)
-_prom(x, y::Missing) = (x,y)
-_prom(x::Missing, y::Missing) = (x,y)
-_prom(x,y)=promote(x,y)
 function _mean(A::AbstractArray, ::Colon)
-    isempty(A) && return one(eltype(A))*NaN
+    isempty(A) && return sum(A)/0
     n = length(A)
     x1 = first(A) / n
-    return sum(x -> first(_prom(x,x1)), A) / n
+    _prom(x::T, y::S) where {T,S} = begin
+        R = promote_type(T, S)
+        return convert(R, x)
+    end
+    return sum(x->_prom(x,x1), A) / n
 end
 
 function mean(r::AbstractRange{<:Real})

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -41,14 +41,11 @@ julia> mean(skipmissing([1, missing, 3]))
 2.0
 ```
 """
-_mean_promote(x::T, y::S) where {T,S} = convert(promote_type(T, S), x)
-
 function mean(itr)
     if isempty(itr)
         return mean(identity, itr)
     end
-    x1 = first(itr)/1
-    return mean(x -> _mean_promote(x, x1), itr)
+    return _mean_promote(itr)
 end
 
 """
@@ -176,11 +173,13 @@ mean(A::AbstractArray; dims=:) = _mean(A, dims)
 
 _mean(A::AbstractArray{T}, region) where {T} = mean!(Base.reducedim_init(t -> t/2, +, A, region), A)
 
-function _mean(A::AbstractArray, ::Colon)
+_mean(A::AbstractArray, ::Colon) = _mean_promote(A)
+function _mean_promote(A)
     isempty(A) && return sum(A)/0
-    n = length(A)
+    n = length(collect(A))
     x1 = first(A) / n
-    return sum(x -> _mean_promote(x, x1), A) / n
+    _prom(x::T, y::S) where {T,S} = convert(promote_type(T, S), x)
+    return sum(x -> _prom(x, x1), A) / n
 end
 
 function mean(r::AbstractRange{<:Real})

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -171,11 +171,8 @@ function _mean(A::AbstractArray, ::Colon)
     isempty(A) && return sum(A)/0
     n = length(A)
     x1 = first(A) / n
-    _prom(x::T, y::S) where {T,S} = begin
-        R = promote_type(T, S)
-        return convert(R, x)
-    end
-    return sum(x->_prom(x,x1), A) / n
+    _prom(x::T, y::S) where {T,S} = convert(promote_type(T, S), x)
+    return sum(x -> _prom(x, x1), A) / n
 end
 
 function mean(r::AbstractRange{<:Real})

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -67,7 +67,7 @@ function mean(f, itr)
     count = 1
     value, state = y
     f_value = f(value)/1
-    total = Base.reduce_first(Base.add_sum, f_value)
+    total = Base.reduce_first(+, f_value)
     y = iterate(itr, state)
     while y !== nothing
         value, state = y

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -163,8 +163,6 @@ julia> mean(A, dims=2)
 """
 mean(A::AbstractArray; dims=:) = _mean(identity, A, dims)
 
-_mean(A::AbstractArray, ::Colon) = _mean(identity, A)
-
 _mean_promote(x::T, y::S) where {T,S} = convert(promote_type(T, S), y)
 
 function _mean(f, A::AbstractArray, dims=:)

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -41,7 +41,15 @@ julia> mean(skipmissing([1, missing, 3]))
 2.0
 ```
 """
-mean(itr) = mean(identity, itr)
+_mean_promote(x::T, y::S) where {T,S} = convert(promote_type(T, S), x)
+
+function mean(itr)
+    if isempty(itr)
+        return mean(identity, itr)
+    end
+    x1 = first(itr)/1
+    return mean(x -> _mean_promote(x, x1), itr)
+end
 
 """
     mean(f::Function, itr)
@@ -167,12 +175,12 @@ julia> mean(A, dims=2)
 mean(A::AbstractArray; dims=:) = _mean(A, dims)
 
 _mean(A::AbstractArray{T}, region) where {T} = mean!(Base.reducedim_init(t -> t/2, +, A, region), A)
+
 function _mean(A::AbstractArray, ::Colon)
     isempty(A) && return sum(A)/0
     n = length(A)
     x1 = first(A) / n
-    _prom(x::T, y::S) where {T,S} = convert(promote_type(T, S), x)
-    return sum(x -> _prom(x, x1), A) / n
+    return sum(x -> _mean_promote(x, x1), A) / n
 end
 
 function mean(r::AbstractRange{<:Real})

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -61,7 +61,7 @@ julia> mean([√1, √2, √3])
 function mean(f, itr)
     y = iterate(itr)
     if y === nothing
-        return Base.mapreduce_empty_iter(f, Base.add_sum, itr,
+        return Base.mapreduce_empty_iter(f, +, itr,
                                          Base.IteratorEltype(itr)) / 0
     end
     count = 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -131,9 +131,9 @@ end
         @test mean(x, dims=2) == [typemax(T)]'
     end
     # Check that mean of integers does not cause catastrophic loss of accuracy
-    let x = fill(typemax(Int), 10)
+    let x = fill(typemax(Int), 10),a=tuple(x...)
         @test (mean(x) == mean(x, dims=1)[] == mean(float, x)
-               ≈ float(typemax(Int)))  # avoid integer overflow (#22)
+               == mean(a) ≈ float(typemax(Int)))  # avoid integer overflow (#22)
     end
     let x = rand(10000)  # mean should use sum's accurate pairwise algorithm
         @test mean(x) == sum(x) / length(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -138,11 +138,11 @@ end
     let x = rand(10000)  # mean should use sum's accurate pairwise algorithm
         @test mean(x) == sum(x) / length(x)
     end
-    @test mean(Number[1, 1.5, 2+3im]) == 1.5+1im # mixed-type array
+    @test mean(Number[1, 1.5, 2+3im]) === 1.5+1im # mixed-type array
     @test isequal(mean(Float64[]), NaN)
     @test isequal(mean(Int[]), NaN)
-    @inferred(Statistics.mean(Int[]))
-    @inferred(Statistics.mean(Float32[]))
+    @inferred mean(Int[])
+    @inferred mean(Float32[])
     @test isequal(typeof(mean(Float32[])), typeof(mean(Float32[1])))
 end
 
@@ -724,7 +724,7 @@ end
     x = Any[1, 2, 4, 10]
     y = Any[1, 2, 4, 10//1]
     @test var(x) === 16.25
-    @test var(y) == 65//4
+    @test var(y) === 16.25
     @test std(x) === sqrt(16.25)
     @test quantile(x, 0.5)  === 3.0
     @test quantile(x, 1//2) === 3//1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -130,10 +130,11 @@ end
         @test mean(identity, x) == mean(identity, g) == typemax(T)
         @test mean(x, dims=2) == [typemax(T)]'
     end
-    # Check that mean of integers does not cause catastrophic loss of accuracy
-    let x = fill(typemax(Int), 10),a=tuple(x...)
+    # Check that mean avoids integer overflow (#22)
+    let x = fill(typemax(Int), 10), a = tuple(x...)
         @test (mean(x) == mean(x, dims=1)[] == mean(float, x)
-               == mean(a) ≈ float(typemax(Int)))  # avoid integer overflow (#22)
+               == mean(a) == mean(v for v in x)  == mean(v for v in a)
+               ≈ float(typemax(Int)))
     end
     let x = rand(10000)  # mean should use sum's accurate pairwise algorithm
         @test mean(x) == sum(x) / length(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -139,11 +139,9 @@ end
         @test mean(x) == sum(x) / length(x)
     end
     @test mean(Number[1, 1.5, 2+3im]) === 1.5+1im # mixed-type array
-    @test isequal(mean(Float64[]), NaN)
-    @test isequal(mean(Int[]), NaN)
-    @inferred mean(Int[])
-    @inferred mean(Float32[])
-    @test isequal(typeof(mean(Float32[])), typeof(mean(Float32[1])))
+    @test @inferred mean(Int[]) === 0.0/0
+    @test @inferred mean(Float64[]) === 0.0/0
+    @test @inferred mean(Float32[]) === 0.0f0/0
 end
 
 @testset "mean/median for ranges" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -144,9 +144,9 @@ end
     @test (@inferred mean(Int[])) === 0/0
     @test (@inferred mean(Float32[])) === 0.f0/0    
     @test (@inferred mean(Float64[])) === 0/0
-    @test (@inferred mean(filter(x -> true, Int[]))) === 0/0
-    @test (@inferred mean(filter(x -> true, Float32[]))) === 0.f0/0
-    @test (@inferred mean(filter(x -> true, Float64[]))) === 0/0
+    @test (@inferred mean(Iterators.filter(x -> true, Int[]))) === 0/0
+    @test (@inferred mean(Iterators.filter(x -> true, Float32[]))) === 0.f0/0
+    @test (@inferred mean(Iterators.filter(x -> true, Float64[]))) === 0/0
 end
 
 @testset "mean/median for ranges" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -139,9 +139,9 @@ end
         @test mean(x) == sum(x) / length(x)
     end
     @test mean(Number[1, 1.5, 2+3im]) === 1.5+1im # mixed-type array
-    @test @inferred mean(Int[]) === 0.0/0
-    @test @inferred mean(Float64[]) === 0.0/0
-    @test @inferred mean(Float32[]) === 0.0f0/0
+    @test (@inferred mean(Int[])) === 0.0/0
+    @test (@inferred mean(Float64[])) === 0.0/0
+    @test (@inferred mean(Float32[])) === 0.0f0/0
 end
 
 @testset "mean/median for ranges" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -141,6 +141,9 @@ end
     @test mean(Number[1, 1.5, 2+3im]) == 1.5+1im # mixed-type array
     @test isequal(mean(Float64[]), NaN)
     @test isequal(mean(Int[]), NaN)
+    @inferred(Statistics.mean(Int[]))
+    @inferred(Statistics.mean(Float32[]))
+    @test isequal(typeof(mean(Float32[])), typeof(mean(Float32[1])))
 end
 
 @testset "mean/median for ranges" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -140,9 +140,13 @@ end
         @test mean(x) == sum(x) / length(x)
     end
     @test mean(Number[1, 1.5, 2+3im]) === 1.5+1im # mixed-type array
-    @test (@inferred mean(Int[])) === 0.0/0
-    @test (@inferred mean(Float64[])) === 0.0/0
-    @test (@inferred mean(Float32[])) === 0.0f0/0
+    @test mean(v for v in Number[1, 1.5, 2+3im]) === 1.5+1im
+    @test (@inferred mean(Int[])) === 0/0
+    @test (@inferred mean(Float32[])) === 0.f0/0    
+    @test (@inferred mean(Float64[])) === 0/0
+    @test (@inferred mean(filter(x -> true, Int[]))) === 0/0
+    @test (@inferred mean(filter(x -> true, Float32[]))) === 0.f0/0
+    @test (@inferred mean(filter(x -> true, Float64[]))) === 0/0
 end
 
 @testset "mean/median for ranges" begin


### PR DESCRIPTION
This PR corrects the issue #22, the bug in mean() on integer inputs.
```
julia> x = [1,1]*typemax(Int);

julia> mean(x)
-1.0

julia> mean(x,dims=1)[]
2.147483647e9
```

Implementation and tests are largely as [proposed](https://github.com/JuliaLang/Statistics.jl/issues/22#issuecomment-587119323) by @stevengj