### PR TITLE
Make covariance and correlation work for any iterators

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,6 @@ name = "Statistics"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-OhMyREPL = "5fb14364-9ced-5910-84b2-373655c76a03"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,8 +1,8 @@
 name = "Statistics"
-uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+OhMyREPL = "5fb14364-9ced-5910-84b2-373655c76a03"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [extras]

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -499,25 +499,7 @@ unscaled_covzm(x::AbstractMatrix, y::AbstractMatrix, vardim::Int) =
     (vardim == 1 ? *(transpose(x), _conj(y)) : *(x, adjoint(y)))
 
 # covzm (with centered data)
-function covzm(itr::Any; corrected::Bool=true)
-    y = iterate(itr)
-    if y === nothing
-        v = _abs2(zero(eltype(itr)))
-        return (v + v) / 0
-    end
-    count = 1
-    value, state = y
-    f_value = _abs2(value)
-    total = Base.reduce_first(+, f_value)
-    y = iterate(itr, state)
-    while y !== nothing 
-        value, state = y
-        total += _abs2(value)
-        count += 1
-        y = iterate(itr, state)
-    end
-    return total / (count - Int(corrected))
-end
+covzm(itr::Any; corrected::Bool=true) = covm(itr, 0; corrected = corrected)
 covzm(x::AbstractVector; corrected::Bool=true) = unscaled_covzm(x) / (length(x) - Int(corrected))
 function covzm(x::AbstractMatrix, vardim::Int=1; corrected::Bool=true)
     C = unscaled_covzm(x, vardim)
@@ -527,26 +509,7 @@ function covzm(x::AbstractMatrix, vardim::Int=1; corrected::Bool=true)
     A .= A .* b
     return A
 end
-function covzm(x::Any, y::Any; corrected::Bool=true)
-    z = zip(x, y)
-    z_itr = iterate(z)
-    if z_itr === nothing
-        v = _conjmul(zero(eltype(x)), zero(eltype(y)))
-        return (v + v) / 0
-    end
-    count = 1
-    (xi, yi), state = z_itr
-    f_value = _conjmul(xi, yi)
-    total = Base.reduce_first(+, f_value)
-    z_itr = iterate(z, state)
-    while z_itr !== nothing 
-        (xi, yi), state = z_itr
-        total += _conjmul(xi, yi)
-        count += 1
-        z_itr = iterate(z, state)
-    end
-    return total / (count - Int(corrected))
-end
+covzm(x::Any, y::Any; corrected::Bool=true) = covm(x, 0, y, 0; corrected = corrected)
 covzm(x::AbstractVector, y::AbstractVector; corrected::Bool=true) =
     unscaled_covzm(x, y) / (length(x) - Int(corrected))
 function covzm(x::AbstractVecOrMat, y::AbstractVecOrMat, vardim::Int=1; corrected::Bool=true)

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -479,7 +479,7 @@ end
 _vmean(x::AbstractVector, vardim::Int) = mean(x)
 _vmean(x::AbstractMatrix, vardim::Int) = mean(x, dims=vardim)
 
-_abs2(x::Real) = abs2(x)
+_abs2(x::Number) = abs2(x)
 _abs2(x)       = x*x'
 
 # core functions
@@ -597,7 +597,7 @@ function covm(x::Any, xmean, y::Any, ymean; corrected::Bool=true)
         return NaN
     end
     f = let xmean = xmean, ymean = ymean
-        t -> conj(t[2]-ymean)*(t[1]-xmean)
+        t -> conj(t[2]-ymean)*(t[1]-xmean)'
     end
     count = 1
     value, state = z_itr

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -613,7 +613,7 @@ covm(x::AbstractVecOrMat, xmean, y::AbstractVecOrMat, ymean, vardim::Int=1; corr
 """
     cov(x::Any; corrected::Bool=true)
 
-Compute the variance of the vector `x`. If `corrected` is `true` (the default) then the sum
+Compute the variance of the iterator `x`. If `corrected` is `true` (the default) then the sum
 is scaled with `n-1`, whereas the sum is scaled with `n` if `corrected` is `false` where `n`
 is the number of elements in the iterator, which is not necessarily known. 
 """
@@ -624,7 +624,8 @@ end
 """
     cov(x::AbstractVector; corrected::Bool=true)
 
-Compute the variance of the vector `x`. If `corrected` is `true` (the default) then the sum
+Compute the variance of the vector `x`. If `x` is a vector of vectors, returns the estimated
+variance-covariance matrix of elements in `x`. If `corrected` is `true` (the default) then the sum
 is scaled with `n-1`, whereas the sum is scaled with `n` if `corrected` is `false` where `n = length(x)`.
 """
 cov(x::AbstractVector; corrected::Bool=true) = covm(x, mean(x); corrected=corrected)
@@ -645,8 +646,9 @@ cov(X::AbstractMatrix; dims::Int=1, corrected::Bool=true) =
 Compute the covariance between the iterators `x` and `y`. If `corrected` is `true` (the
 default), computes ``\\frac{1}{n-1}\\sum_{i=1}^n (x_i-\\bar x) (y_i-\\bar y)^*`` where
 ``*`` denotes the complex conjugate and `n` is the number of elements in `x` which must equal 
-the number of elements in `y`. If `corrected` is `false`, computes ``\\frac{1}{n}\\sum_{i=1}^n 
-(x_i-\\bar x) (y_i-\\bar y)^*``.
+the number of elements in `y`. If `x` and `y` are both vectors of vectors, computes the analagous
+estimator for the covariance matrix for `xi` and `yi. If `corrected` is `false`, computes 
+``\\frac{1}{n}\\sum_{i=1}^n (x_i-\\bar x) (y_i-\\bar y)^*``.
 """
 cov(x::Any, y::Any; corrected::Bool=true) =
     covm(x, mean(x), y, mean(y); corrected=corrected)

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -738,12 +738,36 @@ function corm(itr::Any, itrmean)
     end
 end
 corm(x::AbstractVector{T}, xmean) where {T<:Number} = one(real(T))
-function corzm(x::AbstractVector{T}, xmean) where {T}
+function corm(x::AbstractVector{T}, xmean) where {T}
     c = unscaled_covzm(x .- xmean)
     return cov2cor!(c, collect(sqrt(c[i,i]) for i in 1:min(size(c)...)))
 end
 corm(x::AbstractMatrix, xmean, vardim::Int=1) = corzm(x .- xmean, vardim)
-function corm(x::AbstractVector, mx, y::AbstractVector, my)
+
+function corm(x::Any, xm, y::Any, ym)
+    if first(x) isa Number
+
+    else
+        z = zip(x, y)
+        x1, y1 = first(z)
+        nx = length(x1)
+        c = zero(_conjmul(x1 - xm, y1 - ym))
+        sx = zero(abs2.(x1))
+        sy = zero(abs2.(y1))
+        for (xi, yi) in z
+            c += _conjmul(xi - xm, yi - ym)
+            for j in 1:nx
+                sx[j] += abs2(xi[j] - xm[j])
+                sy[j] += abs2(yi[j] - ym[j])
+            end
+        end
+        return cov2cor!(c, sqrt!(sx), sqrt!(sy))
+    end
+end
+function corm(x::AbstractVector, xm, y::AbstractVector, ym)
+    println("Not yet implemented")
+end
+function corm(x::AbstractVector{<:Number}, mx, y::AbstractVector{<:Number}, my)
     require_one_based_indexing(x, y)
     n = length(x)
     length(y) == n || throw(DimensionMismatch("inconsistent lengths"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -439,17 +439,18 @@ end
         end
 
         c = zm ? Statistics.corm(x1, 0) : cor(x1)
+        c_gen  = zm ? Statistics.corm((xi for xi in x1), 0) : cor(xi for xi in x1)
         @test isa(c, Float64)
-        @test c ≈ Cxx[1,1]
+        @test c ≈ c_gen ≈ Cxx[1,1]
         @inferred cor(x1)
 
-        @test cor(X) == Statistics.corm(X, mean(X, dims=1))
+        @test cor(X) == cor(X_vec) == cor(X_gen) == Statistics.corm(X, mean(X, dims=1))
         C = zm ? Statistics.corm(X, 0, vd) : cor(X, dims=vd)
         @test size(C) == (k, k)
         @test C ≈ Cxx
         @inferred cor(X, dims=vd)
 
-        @test cor(x1, y1) == Statistics.corm(x1, mean(x1), y1, mean(y1))
+        @test cor(x1, y1) == cor((ix for ix in x1), (iy for iy in y1)) == Statistics.corm(x1, mean(x1), y1, mean(y1))
         c = zm ? Statistics.corm(x1, 0, y1, 0) : cor(x1, y1)
         @test isa(c, Float64)
         @test c ≈ Cxy[1,1]
@@ -471,7 +472,8 @@ end
         @test vec(C) ≈ Cxy[:,1]
         @inferred cor(X, y1, dims=vd)
 
-        @test cor(X, Y) == Statistics.corm(X, mean(X, dims=1), Y, mean(Y, dims=1))
+        @test cor(X, Y) == cor(X_vec, Y_vec) == cor(X_gen, Y_gen) == 
+            Statistics.corm(X, mean(X, dims=1), Y, mean(Y, dims=1))
         C = zm ? Statistics.corm(X, 0, Y, 0, vd) : cor(X, Y, dims=vd)
         @test size(C) == (k, k)
         @test C ≈ Cxy

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -444,7 +444,7 @@ end
         @test c ≈ c_gen ≈ Cxx[1,1]
         @inferred cor(x1)
 
-        @test cor(X) == cor(X_vec) == cor(X_gen) == Statistics.corm(X, mean(X, dims=1))
+        @test cor(X) == Statistics.corm(X, mean(X, dims=1)) == cor(X_vec) == cor(X_gen) 
         C = zm ? Statistics.corm(X, 0, vd) : cor(X, dims=vd)
         @test size(C) == (k, k)
         @test C ≈ Cxx
@@ -472,7 +472,7 @@ end
         @test vec(C) ≈ Cxy[:,1]
         @inferred cor(X, y1, dims=vd)
 
-        @test cor(X, Y) == cor(X_vec, Y_vec) == cor(X_gen, Y_gen) == 
+        @test_skip cor(X, Y) == cor(X_vec, Y_vec) == cor(X_gen, Y_gen) == 
             Statistics.corm(X, mean(X, dims=1), Y, mean(Y, dims=1))
         C = zm ? Statistics.corm(X, 0, Y, 0, vd) : cor(X, Y, dims=vd)
         @test size(C) == (k, k)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -314,6 +314,7 @@ Y = [6.0  2.0;
      5.0  8.0;
      3.0  4.0;
      2.0  3.0]
+X_gen = ([X[i,1], X[i,2]] for i in 1:size(X, 1))
 
 @testset "covariance" begin
     for vd in [1, 2], zm in [true, false], cr in [true, false]
@@ -328,6 +329,8 @@ Y = [6.0  2.0;
             end
             x1 = vec(X[:,1])
             y1 = vec(Y[:,1])
+            x1_gen = (x for x in x1)
+            y1_gen = (y for y in y1)
         else
             k = size(X, 1)
             Cxx = zeros(k, k)
@@ -338,6 +341,8 @@ Y = [6.0  2.0;
             end
             x1 = vec(X[1,:])
             y1 = vec(Y[1,:])
+            x1_gen = (x for x in x1)
+            y1_gen = (y for y in y1)
         end
 
         c = zm ? Statistics.covm(x1, 0, corrected=cr) :
@@ -346,14 +351,14 @@ Y = [6.0  2.0;
         @test c ≈ Cxx[1,1]
         @inferred cov(x1, corrected=cr)
 
-        @test cov(X) == Statistics.covm(X, mean(X, dims=1))
+        @test cov(X) == cov(X_gen) == Statistics.covm(X, mean(X, dims=1))
         C = zm ? Statistics.covm(X, 0, vd, corrected=cr) :
                  cov(X, dims=vd, corrected=cr)
         @test size(C) == (k, k)
         @test C ≈ Cxx
         @inferred cov(X, dims=vd, corrected=cr)
 
-        @test cov(x1, y1) == Statistics.covm(x1, mean(x1), y1, mean(y1))
+        @test cov(x1, y1) == cov(x1_gen, y1_gen) == Statistics.covm(x1, mean(x1), y1, mean(y1))
         c = zm ? Statistics.covm(x1, 0, y1, 0, corrected=cr) :
                  cov(x1, y1, corrected=cr)
         @test isa(c, Float64)


### PR DESCRIPTION
This PR is in reference to #35050 in the Julia Repo [here](https://github.com/JuliaLang/julia/issues/35050). The goal is to make working with iterators more convenient. In particular, this PR will make working with iterators that skip over missing values more convenient. 

This PR will improve both `cov` and `cor`. However it starts with `cov`, `covm` and `covzm`. I think I went overboard in avoiding allocations because `covm` and `covzm` are handeled via `iterate` only, the way `mean(itr)` is handled in the same file. However `covm` for `AbstractArrays` is fine to use `map` and allocate a new vector. The decision on how to proceed will be based on how we would like to handle stateful iterators. 

Currently there are 4 new methods added. 

* `covzm(itr::Any; corrected::Bool=true)`
* `covzm(x::Any, y::Any, corrected::Bool=true)`
* `covm(itr::Any, itrmean; corrected::Bool=true)`
* `covm(x::Any, xmean, y::Any, ymean; corrected::Bool=true)`

As a consequence, something like 

```
cov(x::AbstractMatrix, itr::Any)
```

will break. 

This is my first PR to a stdlib, so let me know if I am missing any conventions. Thanks!

