### PR TITLE
Add missing shape checks for the means argument to var[m] and std[m]

### DIFF
--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -235,7 +235,7 @@ centralize_sumabs2(A::AbstractArray, m, ifirst::Int, ilast::Int) =
 function centralize_sumabs2!(R::AbstractArray{S}, A::AbstractArray, means::AbstractArray) where S
     # following the implementation of _mapreducedim! at base/reducedim.jl
     lsiz = Base.check_reducedims(R,A)
-    for i in 1:ndims(R)
+    for i in 1:max(ndims(R), ndims(means))
         if axes(means, i) != axes(R, i)
             throw(DimensionMismatch("dimension $i of `mean` should have indices $(axes(R, i)), but got $(axes(means, i))"))
         end
@@ -1062,7 +1062,7 @@ end
 function centralize_sumabs2!(R::AbstractArray{S}, A::SparseMatrixCSC{Tv,Ti}, means::AbstractArray) where {S,Tv,Ti}
     require_one_based_indexing(R, A, means)
     lsiz = Base.check_reducedims(R,A)
-    for i in 1:ndims(R)
+    for i in 1:max(ndims(R), ndims(means))
         if axes(means, i) != axes(R, i)
             throw(DimensionMismatch("dimension $i of `mean` should have indices $(axes(R, i)), but got $(axes(means, i))"))
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -302,12 +302,13 @@ end
         @test var(x, dims=2, mean=mean(x, dims=2)) == var(x, dims=2)
         @test var(x, dims=2, mean=reshape(mean(x, dims=2), :)) == var(x, dims=2)
         @test var(x, dims=2, mean=reshape(mean(x, dims=2), :, 1, 1)) == var(x, dims=2)
-        @test_throws DimensionMismatch var(x, dims=1, mean=reshape(mean(x, dims=1), :))
-        @test_throws DimensionMismatch var(x, dims=1, mean=reshape(mean(x, dims=1), :, 1))
-        @test_throws DimensionMismatch var(x, dims=2, mean=reshape(mean(x, dims=2), 1, :))
-        @test_throws DimensionMismatch var(x, dims=1, mean=reshape(mean(x, dims=1), 1, 1, :))
-        @test_throws DimensionMismatch var(x, dims=2, mean=reshape(mean(x, dims=2), 1, :, 1))
-        @test_throws DimensionMismatch var(x, dims=2, mean=reshape(mean(x, dims=2), 1, 1, :))
+        @test_throws DimensionMismatch var(x, dims=1, mean=ones(size(x, 1)))
+        @test_throws DimensionMismatch var(x, dims=1, mean=ones(size(x, 1), 1))
+        @test_throws DimensionMismatch var(x, dims=2, mean=ones(1, size(x, 2)))
+        @test_throws DimensionMismatch var(x, dims=1, mean=ones(1, 1, size(x, 2)))
+        @test_throws DimensionMismatch var(x, dims=2, mean=ones(1, size(x, 2), 1))
+        @test_throws DimensionMismatch var(x, dims=2, mean=ones(size(x, 1), 1, 5))
+        @test_throws DimensionMismatch var(x, dims=1, mean=ones(1, size(x, 2), 5))
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -294,6 +294,21 @@ end
     @test var(Int[]) isa Float64
     @test isequal(var(skipmissing(Int[])), NaN)
     @test var(skipmissing(Int[])) isa Float64
+
+    # over dimensions with provided means
+    for x in ([1 2 3; 4 5 6], sparse([1 2 3; 4 5 6]))
+        @test var(x, dims=1, mean=mean(x, dims=1)) == var(x, dims=1)
+        @test var(x, dims=1, mean=reshape(mean(x, dims=1), 1, :, 1)) == var(x, dims=1)
+        @test var(x, dims=2, mean=mean(x, dims=2)) == var(x, dims=2)
+        @test var(x, dims=2, mean=reshape(mean(x, dims=2), :)) == var(x, dims=2)
+        @test var(x, dims=2, mean=reshape(mean(x, dims=2), :, 1, 1)) == var(x, dims=2)
+        @test_throws DimensionMismatch var(x, dims=1, mean=reshape(mean(x, dims=1), :))
+        @test_throws DimensionMismatch var(x, dims=1, mean=reshape(mean(x, dims=1), :, 1))
+        @test_throws DimensionMismatch var(x, dims=2, mean=reshape(mean(x, dims=2), 1, :))
+        @test_throws DimensionMismatch var(x, dims=1, mean=reshape(mean(x, dims=1), 1, 1, :))
+        @test_throws DimensionMismatch var(x, dims=2, mean=reshape(mean(x, dims=2), 1, :, 1))
+        @test_throws DimensionMismatch var(x, dims=2, mean=reshape(mean(x, dims=2), 1, 1, :))
+    end
 end
 
 function safe_cov(x, y, zm::Bool, cr::Bool)


### PR DESCRIPTION
We use `@inbounds`, but the shape of the `means` argument was never checked for the general `AbstractArray` method. With an incorrect shape, invalid results or crashes would happen.
To avoid breaking existing code which was working, allow trailing singleton dimensions. Sync the `SparseMatrixCSV` method, which makes it less strict.

See [this Discourse thread](https://discourse.julialang.org/t/bug-in-var-when-supplying-means-as-vectors/36979).