### PR TITLE
remove test for empty tuple for mean

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -67,7 +67,6 @@ end
 end
 
 @testset "mean" begin
-    @test_throws MethodError mean(())
     @test mean((1,2,3)) === 2.
     @test mean([0]) === 0.
     @test mean([1.]) === 1.


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/35803 broke the tests for Statistics because an ambiguity was fixed:

```
julia> using Statistics

julia> mean(())
ERROR: MethodError: reduce_empty(::typeof(Base.add_sum), ::Type{Union{}}) is ambiguous. Candidates:
  reduce_empty(::typeof(Base.add_sum), ::Type{T}) where T<:Union{Int16, Int32, Int8} in Base at reduce.jl:314
  reduce_empty(::typeof(Base.add_sum), ::Type{T}) where T<:Union{UInt16, UInt32, UInt8} in Base at reduce.jl:315
Possible fix, define
  reduce_empty(::typeof(Base.add_sum), ::Type{Union{}})
```
which after that PR is now (more correctly):

```
julia> mean(())
ERROR: ArgumentError: reducing over an empty collection is not allowed
```

This test doesn't seem to do anything so just delete it.