### PR TITLE
Force specialization for _mean's dims argument

### DIFF
--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -165,7 +165,7 @@ mean(A::AbstractArray; dims=:) = _mean(identity, A, dims)
 
 _mean_promote(x::T, y::S) where {T,S} = convert(promote_type(T, S), y)
 
-function _mean(f, A::AbstractArray, dims=:)
+function _mean(f, A::AbstractArray, dims::Dims=:) where Dims
     isempty(A) && return sum(f, A, dims=dims)/0
     if dims === (:)
         n = length(A)

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -165,6 +165,7 @@ mean(A::AbstractArray; dims=:) = _mean(identity, A, dims)
 
 _mean_promote(x::T, y::S) where {T,S} = convert(promote_type(T, S), y)
 
+# ::Dims is there to force specializing on Colon (as it is a Function)
 function _mean(f, A::AbstractArray, dims::Dims=:) where Dims
     isempty(A) && return sum(f, A, dims=dims)/0
     if dims === (:)


### PR DESCRIPTION
Ensures we get the specialization we want when passing `dims=(:)`.  Fixes #37.