### PR TITLE
README: Add the Travis CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Statistics.jl
 
+[![Travis CI Build Status][travis-img]][travis-url]
+
 Development repository for the Statistics standard library (stdlib) that ships with Julia. 
 
 #### Using the development version of Statistics.jl
@@ -12,3 +14,6 @@ If you want to develop this package, do the following steps:
 - To test your changes, simply do `include("test/runtests.jl")`.
 
 If you need to build Julia from source with a git checkout of Statistics, then instead use `make DEPS_GIT=Statistics` when building Julia. The `Statistics` repo is in `stdlib/Statistics`, and created initially with a detached `HEAD`. If you're doing this from a pre-existing Julia repository, you may need to `make clean` beforehand.
+
+[travis-img]: https://travis-ci.com/JuliaLang/Statistics.jl.svg?branch=master
+[travis-url]: https://travis-ci.com/JuliaLang/Statistics.jl


### PR DESCRIPTION
This pull request adds the Travis CI status badge to the README.