### PR TITLE
change real to float in cor of a single collection

### DIFF
--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -657,7 +657,7 @@ end
 
 # corzm (non-exported, with centered data)
 
-corzm(x::AbstractVector{T}) where {T} = one(real(T))
+corzm(x::AbstractVector{T}) where {T} = one(float(T))
 function corzm(x::AbstractMatrix, vardim::Int=1)
     c = unscaled_covzm(x, vardim)
     return cov2cor!(c, collect(sqrt(c[i,i]) for i in 1:min(size(c)...)))
@@ -671,7 +671,7 @@ corzm(x::AbstractMatrix, y::AbstractMatrix, vardim::Int=1) =
 
 # corm
 
-corm(x::AbstractVector{T}, xmean) where {T} = one(real(T))
+corm(x::AbstractVector{T}, xmean) where {T} = one(float(T))
 corm(x::AbstractMatrix, xmean, vardim::Int=1) = corzm(x .- xmean, vardim)
 function corm(x::AbstractVector, mx, y::AbstractVector, my)
     require_one_based_indexing(x, y)
@@ -705,7 +705,7 @@ corm(x::AbstractVecOrMat, xmean, y::AbstractVecOrMat, ymean, vardim::Int=1) =
 
 Return the number one.
 """
-cor(x::AbstractVector) = one(real(eltype(x)))
+cor(x::AbstractVector) = one(float(eltype(x)))
 
 """
     cor(X::AbstractMatrix; dims::Int=1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -516,6 +516,20 @@ end
         @test cor(tmp, tmp) <= 1.0
         @test cor(tmp, tmp2) <= 1.0
     end
+    
+    @test cor(Int[]) === 1.0
+    @test cor([im]) ===1.0 + 0.0im
+    @test_throws MethodError cor([])
+    @test_throws MethodError cor(Any[1.0])
+    
+    @test cor([1, missing]) === 1.0
+    @test ismissing(cor([missing]))
+    @test_throws MethodError cor(Any[1.0, missing])
+    
+    @test Statistics.corm([true], 1.0) === 1.0
+    @test_throws MethodError Statistics.corm(Any[0.0, 1.0], 0.5)
+    @test Statistics.corzm([true]) === 1.0
+    @test_throws MethodError Statistics.corzm(Any[0.0, 1.0])
 end
 
 @testset "quantile" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -518,7 +518,7 @@ end
     end
     
     @test cor(Int[]) === 1.0
-    @test cor([im]) ===1.0 + 0.0im
+    @test cor([im]) === 1.0 + 0.0im
     @test_throws MethodError cor([])
     @test_throws MethodError cor(Any[1.0])
     


### PR DESCRIPTION
As in `cor` we get square root I think it is safe to assume that the result should be floating point.

An example of current surprising behavior:
```
julia> cor([im])
true
```