### PR TITLE
In var, don't compute the mean if provided

### DIFF
--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -367,11 +367,19 @@ singleton dimensions are allowed).
 """
 var(A::AbstractArray; corrected::Bool=true, mean=nothing, dims=:) = _var(A, corrected, mean, dims)
 
-_var(A::AbstractArray, corrected::Bool, mean, dims) =
-    varm(A, something(mean, Statistics.mean(A, dims=dims)); corrected=corrected, dims=dims)
+function _var(A::AbstractArray, corrected::Bool, mean, dims)
+  if mean === nothing
+    mean = Statistics.mean(A, dims=dims)
+  end
+  return varm(A, mean; corrected=corrected, dims=dims)
+end
 
-_var(A::AbstractArray, corrected::Bool, mean, ::Colon) =
-    real(varm(A, something(mean, Statistics.mean(A)); corrected=corrected))
+function _var(A::AbstractArray, corrected::Bool, mean, ::Colon)
+  if mean === nothing
+    mean = Statistics.mean(A)
+  end
+  return real(varm(A, mean; corrected=corrected))
+end
 
 varm(iterable, m; corrected::Bool=true) = _var(iterable, corrected, m)
 

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -369,14 +369,14 @@ var(A::AbstractArray; corrected::Bool=true, mean=nothing, dims=:) = _var(A, corr
 
 function _var(A::AbstractArray, corrected::Bool, mean, dims)
   if mean === nothing
-    mean = Statistics.mean(A, dims=dims)
+      mean = Statistics.mean(A, dims=dims)
   end
   return varm(A, mean; corrected=corrected, dims=dims)
 end
 
 function _var(A::AbstractArray, corrected::Bool, mean, ::Colon)
   if mean === nothing
-    mean = Statistics.mean(A)
+      mean = Statistics.mean(A)
   end
   return real(varm(A, mean; corrected=corrected))
 end


### PR DESCRIPTION
As mentioned in #12, `var` currently calculates the mean even if provided through the `mean` keyword argument.

Before this PR:

```
v = rand(100000);
μ = mean(v);

julia> @btime var($v, mean=$μ)
  33.777 μs (0 allocations: 0 bytes)
```

After:

```
julia> @btime var($v, mean=$μ)
  17.571 μs (0 allocations: 0 bytes)
```