### PR TITLE
Fix detection of NaN in median()

### DIFF
--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -794,7 +794,7 @@ Like [`median`](@ref), but may overwrite the input vector.
 function median!(v::AbstractVector)
     isempty(v) && throw(ArgumentError("median of an empty array is undefined, $(repr(v))"))
     eltype(v)>:Missing && any(ismissing, v) && return missing
-    (eltype(v)<:AbstractFloat || eltype(v)>:AbstractFloat) && any(isnan, v) && return convert(eltype(v), NaN)
+    any(x -> x isa Number && isnan(x), v) && return convert(eltype(v), NaN)
     inds = axes(v, 1)
     n = length(inds)
     mid = div(first(inds)+last(inds),2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,6 +48,7 @@ end
     @test isnan(median([NaN,0.0]))
     @test isnan(median([NaN,0.0,1.0]))
     @test isnan(median(Any[NaN,0.0,1.0]))
+    @test isnan(median(median(Union{Float64, Missing}[1, 2, 3, NaN])))
     @test isequal(median([NaN 0.0; 1.2 4.5], dims=2), reshape([NaN; 2.85], 2, 1))
 
     @test ismissing(median([1, missing]))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,7 +48,6 @@ end
     @test isnan(median([NaN,0.0]))
     @test isnan(median([NaN,0.0,1.0]))
     @test isnan(median(Any[NaN,0.0,1.0]))
-    @test isnan(median(median(Union{Float64, Missing}[1, 2, 3, NaN])))
     @test isequal(median([NaN 0.0; 1.2 4.5], dims=2), reshape([NaN; 2.85], 2, 1))
 
     @test ismissing(median([1, missing]))
@@ -68,6 +67,15 @@ end
     @test @inferred(median(Float16[1, 2, 3]))   === Float16(2)
     @test @inferred(median(Float32[1, 2, NaN])) === NaN32
     @test @inferred(median(Float32[1, 2, 3]))   === 2.0f0
+
+    # custom type implementing minimal interface
+    struct A
+        x
+    end
+    Statistics.middle(x::A, y::A) = A(middle(x.x, y.x))
+    Base.isless(x::A, y::A) = isless(x.x, y.x)
+    @test median([A(1), A(2)]) === A(1.5)
+    @test median(Any[A(1), A(2)]) === A(1.5)
 end
 
 @testset "mean" begin


### PR DESCRIPTION
There is no reliable way to know only from the array eltype whether entries support `isnan` or not. Better leave to the compiler to optimize out the `isa Number` check when possible.

This works thanks to `isnan(::Number)` added by https://github.com/JuliaLang/julia/pull/38232.