### PR TITLE
Allow computing the correlation matrix from the covariance matrix only

### DIFF
--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -662,6 +662,7 @@ function cov2cor!(C::AbstractMatrix, xsd::AbstractArray, ysd::AbstractArray)
     end
     return C
 end
+cov2cor!(C::AbstractMatrix{T}, xsd::AbstractArray=[sqrt(C[i,i]) for i in 1:size(C, 1)])
 
 # corzm (non-exported, with centered data)
 


### PR DESCRIPTION
Following discussions concerning issue JuliaStats/StatsBase.jl#652.