### PR TITLE
Fix missing `stdm` method with dims argument

### DIFF
--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -419,8 +419,8 @@ function sqrt!(A::AbstractArray)
     A
 end
 
-stdm(A::AbstractArray, m; corrected::Bool=true) =
-    sqrt.(varm(A, m; corrected=corrected))
+stdm(A::AbstractArray, m; corrected::Bool=true, dims=:) =
+    sqrt.(varm(A, m; corrected=corrected, dims=dims))
 
 """
     std(itr; corrected::Bool=true, mean=nothing[, dims])
@@ -467,7 +467,7 @@ std(iterable; corrected::Bool=true, mean=nothing) =
     sqrt(var(iterable, corrected=corrected, mean=mean))
 
 """
-    stdm(itr, mean; corrected::Bool=true)
+    stdm(itr, mean; corrected::Bool=true, dims)
 
 Compute the sample standard deviation of collection `itr`, with known mean(s) `mean`.
 

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -487,14 +487,11 @@ over dimensions. In that case, `mean` must be an array with the same shape as
     Use the [`skipmissing`](@ref) function to omit `missing` entries and compute the
     standard deviation of non-missing values.
 """
-stdm(A::AbstractArray, m; corrected::Bool=true) =
-    sqrt.(varm(A, m; corrected=corrected))
-
 stdm(A::AbstractArray, m::AbstractArray; corrected::Bool=true, dims=:) =
-    sqrt.(varm(A, m; corrected=corrected, dims=dims))
+    _std(A, corrected, m, dims)
 
 stdm(iterable, m; corrected::Bool=true) =
-    std(iterable, corrected=corrected, mean=m)
+    sqrt(var(iterable, corrected=corrected, mean=mean))
 
 
 ###### covariance ######

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -464,7 +464,7 @@ std(iterable; corrected::Bool=true, mean=nothing) =
     sqrt(var(iterable, corrected=corrected, mean=mean))
 
 """
-    stdm(itr, mean; corrected::Bool=true, dims)
+    stdm(itr, mean; corrected::Bool=true[, dims])
 
 Compute the sample standard deviation of collection `itr`, with known mean(s) `mean`.
 

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -419,9 +419,6 @@ function sqrt!(A::AbstractArray)
     A
 end
 
-stdm(A::AbstractArray, m; corrected::Bool=true, dims=:) =
-    sqrt.(varm(A, m; corrected=corrected, dims=dims))
-
 """
     std(itr; corrected::Bool=true, mean=nothing[, dims])
 
@@ -490,6 +487,12 @@ over dimensions. In that case, `mean` must be an array with the same shape as
     Use the [`skipmissing`](@ref) function to omit `missing` entries and compute the
     standard deviation of non-missing values.
 """
+stdm(A::AbstractArray, m; corrected::Bool=true) =
+    sqrt.(varm(A, m; corrected=corrected))
+
+stdm(A::AbstractArray, m::AbstractArray; corrected::Bool=true, dims=:) =
+    sqrt.(varm(A, m; corrected=corrected, dims=dims))
+
 stdm(iterable, m; corrected::Bool=true) =
     std(iterable, corrected=corrected, mean=m)
 

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -491,7 +491,7 @@ stdm(A::AbstractArray, m::AbstractArray; corrected::Bool=true, dims=:) =
     _std(A, corrected, m, dims)
 
 stdm(iterable, m; corrected::Bool=true) =
-    sqrt(var(iterable, corrected=corrected, mean=mean))
+    sqrt(var(iterable, corrected=corrected, mean=m))
 
 
 ###### covariance ######

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -259,6 +259,7 @@ end
     @test std([1.0,2,3]; mean=0) ≈ sqrt(7.0)
     @test std([1.0,2,3]; mean=0, corrected=false) ≈ sqrt(14.0/3)
 
+    @test stdm([1.0,2,3], [0]; dims=1, corrected=false)[] ≈ sqrt(14.0/3)
     @test std([1.0,2,3]; dims=1)[] ≈ 1.
     @test std([1.0,2,3]; dims=1, corrected=false)[] ≈ sqrt(2.0/3)
     @test std([1.0,2,3]; dims=1, mean=[0])[] ≈ sqrt(7.0)
@@ -270,6 +271,8 @@ end
     @test std((1,2,3); mean=0) ≈ sqrt(7.0)
     @test std((1,2,3); mean=0, corrected=false) ≈ sqrt(14.0/3)
 
+    @test stdm([1 2 3 4 5; 6 7 8 9 10], [3.0,8.0], dims=2) ≈ sqrt.([2.5 2.5]')
+    @test stdm([1 2 3 4 5; 6 7 8 9 10], [3.0,8.0], dims=2; corrected=false) ≈ sqrt.([2.0 2.0]')
     @test std([1 2 3 4 5; 6 7 8 9 10], dims=2) ≈ sqrt.([2.5 2.5]')
     @test std([1 2 3 4 5; 6 7 8 9 10], dims=2; corrected=false) ≈ sqrt.([2.0 2.0]')
 


### PR DESCRIPTION
`stdm` is missing a "dims" argument which is documented but has not actually been added.